### PR TITLE
fix gateway reconnecting bug

### DIFF
--- a/discord/opcodes.go
+++ b/discord/opcodes.go
@@ -1,7 +1,5 @@
 package discord
 
-import "github.com/gorilla/websocket"
-
 // GatewayOpcode are opcodes used by discord
 type GatewayOpcode int
 
@@ -43,8 +41,7 @@ const (
 
 func (c GatewayCloseEventCode) ShouldReconnect() bool {
 	switch c {
-	case websocket.CloseNormalClosure,
-		GatewayCloseEventCodeAuthenticationFailed,
+	case GatewayCloseEventCodeAuthenticationFailed,
 		GatewayCloseEventCodeInvalidShard,
 		GatewayCloseEventCodeShardingRequired,
 		GatewayCloseEventCodeInvalidAPIVersion,


### PR DESCRIPTION
it seems like discord can close the websocket with the 1000 code which we treated to not reconnect atm

* reconnect on webscoket close code 1000
* don't reconnect on net.ErrClosed
* move resume logging to debug