### PR TITLE
Go get is no longer  supported outside a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ After v1 is released breaking changes may only happen if the Discord API require
 ### Installing
 
 ```sh
-go get github.com/disgoorg/disgo
+go install github.com/disgoorg/disgo@latest
 ```
 
 ### Building a DisGo Instance


### PR DESCRIPTION
For more information, see https://golang.org/doc/go-get-install-deprecation