### PR TITLE
improve presence UX

### DIFF
--- a/_examples/test/examplebot.go
+++ b/_examples/test/examplebot.go
@@ -10,6 +10,7 @@ import (
 	"github.com/disgoorg/disgo"
 	"github.com/disgoorg/disgo/bot"
 	"github.com/disgoorg/disgo/cache"
+	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/gateway"
 	"github.com/disgoorg/log"
 	"github.com/disgoorg/snowflake/v2"
@@ -32,7 +33,7 @@ func main() {
 	client, err := disgo.New(token,
 		bot.WithGatewayConfigOpts(
 			gateway.WithIntents(gateway.IntentsNonPrivileged, gateway.IntentMessageContent),
-			gateway.WithPresenceOpts(gateway.WithListeningActivity("your bullshit")),
+			gateway.WithPresenceOpts(gateway.WithListeningActivity("your bullshit"), gateway.WithOnlineStatus(discord.OnlineStatusDND)),
 		),
 		bot.WithCacheConfigOpts(
 			cache.WithCacheFlags(cache.FlagsAll),

--- a/_examples/test/examplebot.go
+++ b/_examples/test/examplebot.go
@@ -10,7 +10,6 @@ import (
 	"github.com/disgoorg/disgo"
 	"github.com/disgoorg/disgo/bot"
 	"github.com/disgoorg/disgo/cache"
-	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/gateway"
 	"github.com/disgoorg/log"
 	"github.com/disgoorg/snowflake/v2"
@@ -33,7 +32,7 @@ func main() {
 	client, err := disgo.New(token,
 		bot.WithGatewayConfigOpts(
 			gateway.WithIntents(gateway.IntentsNonPrivileged, gateway.IntentMessageContent),
-			gateway.WithPresence(gateway.NewListeningPresence("your bullshit", discord.OnlineStatusOnline, false)),
+			gateway.WithPresenceOpts(gateway.WithListeningActivity("your bullshit")),
 		),
 		bot.WithCacheConfigOpts(
 			cache.WithCacheFlags(cache.FlagsAll),

--- a/bot/client.go
+++ b/bot/client.go
@@ -280,7 +280,8 @@ func (c *clientImpl) SetPresence(ctx context.Context, opts ...gateway.PresenceOp
 	if !c.HasGateway() {
 		return discord.ErrNoGateway
 	}
-	return c.gateway.Send(ctx, gateway.OpcodePresenceUpdate, getPresenceFromOpts(opts...))
+	g := c.gateway
+	return g.Send(ctx, gateway.OpcodePresenceUpdate, applyPresenceFromOpts(g, opts...))
 }
 
 func (c *clientImpl) SetPresenceForShard(ctx context.Context, shardId int, opts ...gateway.PresenceOpt) error {
@@ -291,11 +292,14 @@ func (c *clientImpl) SetPresenceForShard(ctx context.Context, shardId int, opts 
 	if shard == nil {
 		return discord.ErrShardNotFound
 	}
-	return shard.Send(ctx, gateway.OpcodePresenceUpdate, getPresenceFromOpts(opts...))
+	return shard.Send(ctx, gateway.OpcodePresenceUpdate, applyPresenceFromOpts(shard, opts...))
 }
 
-func getPresenceFromOpts(opts ...gateway.PresenceOpt) gateway.MessageDataPresenceUpdate {
-	presenceUpdate := &gateway.MessageDataPresenceUpdate{}
+func applyPresenceFromOpts(g gateway.Gateway, opts ...gateway.PresenceOpt) gateway.MessageDataPresenceUpdate {
+	presenceUpdate := g.Presence()
+	if presenceUpdate == nil {
+		presenceUpdate = &gateway.MessageDataPresenceUpdate{}
+	}
 	for _, opt := range opts {
 		opt(presenceUpdate)
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -100,4 +100,7 @@ type Gateway interface {
 	// Latency returns the latency of the Gateway.
 	// This is calculated by the time it takes to send a heartbeat and receive a heartbeat ack by discord.
 	Latency() time.Duration
+
+	// Presence returns the current presence of the Gateway.
+	Presence() *MessageDataPresenceUpdate
 }

--- a/gateway/gateway_config.go
+++ b/gateway/gateway_config.go
@@ -184,11 +184,11 @@ func WithRateRateLimiterConfigOpts(opts ...RateLimiterConfigOpt) ConfigOpt {
 // WithPresenceOpts allows to pass initial presence data the bot should display.
 func WithPresenceOpts(opts ...PresenceOpt) ConfigOpt {
 	return func(config *Config) {
-		presence := &MessageDataPresenceUpdate{}
+		presenceUpdate := &MessageDataPresenceUpdate{}
 		for _, opt := range opts {
-			opt(presence)
+			opt(presenceUpdate)
 		}
-		config.Presence = presence
+		config.Presence = presenceUpdate
 	}
 }
 

--- a/gateway/gateway_config.go
+++ b/gateway/gateway_config.go
@@ -60,6 +60,8 @@ func (c *Config) Apply(opts []ConfigOpt) {
 	}
 }
 
+type PresenceOpt func(presenceUpdate *MessageDataPresenceUpdate)
+
 // WithLogger sets the Logger for the Gateway.
 func WithLogger(logger log.Logger) ConfigOpt {
 	return func(config *Config) {
@@ -179,10 +181,14 @@ func WithRateRateLimiterConfigOpts(opts ...RateLimiterConfigOpt) ConfigOpt {
 	}
 }
 
-// WithPresence sets the initial presence the bot should display.
-func WithPresence(presence MessageDataPresenceUpdate) ConfigOpt {
+// WithPresenceOpts allows to pass initial presence data the bot should display.
+func WithPresenceOpts(opts ...PresenceOpt) ConfigOpt {
 	return func(config *Config) {
-		config.Presence = &presence
+		presence := &MessageDataPresenceUpdate{}
+		for _, opt := range opts {
+			opt(presence)
+		}
+		config.Presence = presence
 	}
 }
 

--- a/gateway/gateway_config.go
+++ b/gateway/gateway_config.go
@@ -60,8 +60,6 @@ func (c *Config) Apply(opts []ConfigOpt) {
 	}
 }
 
-type PresenceOpt func(presenceUpdate *MessageDataPresenceUpdate)
-
 // WithLogger sets the Logger for the Gateway.
 func WithLogger(logger log.Logger) ConfigOpt {
 	return func(config *Config) {

--- a/gateway/gateway_impl.go
+++ b/gateway/gateway_impl.go
@@ -204,6 +204,10 @@ func (g *gatewayImpl) Latency() time.Duration {
 	return g.lastHeartbeatReceived.Sub(g.lastHeartbeatSent)
 }
 
+func (g *gatewayImpl) Presence() *MessageDataPresenceUpdate {
+	return g.config.Presence
+}
+
 func (g *gatewayImpl) reconnectTry(ctx context.Context, try int, delay time.Duration) error {
 	if try >= g.config.MaxReconnectTries-1 {
 		return fmt.Errorf("failed to reconnect. exceeded max reconnect tries of %d reached", g.config.MaxReconnectTries)

--- a/gateway/gateway_messages.go
+++ b/gateway/gateway_messages.go
@@ -488,10 +488,8 @@ func WithOnlineStatus(status discord.OnlineStatus) PresenceOpt {
 	return func(presence *MessageDataPresenceUpdate) {
 		presence.Status = status
 		if status == discord.OnlineStatusIdle {
-			var since *int64
-			unix := time.Now().Unix()
-			since = &unix
-			presence.Since = since
+			since := time.Now().Unix()
+			presence.Since = &since
 		}
 	}
 }

--- a/gateway/gateway_messages.go
+++ b/gateway/gateway_messages.go
@@ -438,6 +438,7 @@ type IdentifyCommandDataProperties struct {
 
 type PresenceOpt func(presenceUpdate *MessageDataPresenceUpdate)
 
+// WithPlayingActivity creates a new "Playing ..." activity of type discord.ActivityTypeGame
 func WithPlayingActivity(name string) PresenceOpt {
 	return withActivity(discord.Activity{
 		Name: name,
@@ -445,6 +446,7 @@ func WithPlayingActivity(name string) PresenceOpt {
 	})
 }
 
+// WithStreamingActivity creates a new "Streaming ..." activity of type discord.ActivityTypeStreaming
 func WithStreamingActivity(name string, url string) PresenceOpt {
 	activity := discord.Activity{
 		Name: name,
@@ -456,6 +458,7 @@ func WithStreamingActivity(name string, url string) PresenceOpt {
 	return withActivity(activity)
 }
 
+// WithListeningActivity creates a new "Listening to ..." activity of type discord.ActivityTypeListening
 func WithListeningActivity(name string) PresenceOpt {
 	return withActivity(discord.Activity{
 		Name: name,
@@ -463,6 +466,7 @@ func WithListeningActivity(name string) PresenceOpt {
 	})
 }
 
+// WithWatchingActivity creates a new "Watching ..." activity of type discord.ActivityTypeWatching
 func WithWatchingActivity(name string) PresenceOpt {
 	return withActivity(discord.Activity{
 		Name: name,
@@ -470,6 +474,7 @@ func WithWatchingActivity(name string) PresenceOpt {
 	})
 }
 
+// WithCompetingActivity creates a new "Competing in ..." activity of type discord.ActivityTypeCompeting
 func WithCompetingActivity(name string) PresenceOpt {
 	return withActivity(discord.Activity{
 		Name: name,
@@ -483,18 +488,21 @@ func withActivity(activity discord.Activity) PresenceOpt {
 	}
 }
 
+// WithOnlineStatus sets the online status to the provided discord.OnlineStatus
 func WithOnlineStatus(status discord.OnlineStatus) PresenceOpt {
 	return func(presence *MessageDataPresenceUpdate) {
 		presence.Status = status
 	}
 }
 
+// WithAfk sets whether the session is afk
 func WithAfk(afk bool) PresenceOpt {
 	return func(presence *MessageDataPresenceUpdate) {
 		presence.AFK = afk
 	}
 }
 
+// WithSince sets when the session has gone afk
 func WithSince(since *int64) PresenceOpt {
 	return func(presence *MessageDataPresenceUpdate) {
 		presence.Since = since

--- a/gateway/gateway_messages.go
+++ b/gateway/gateway_messages.go
@@ -478,7 +478,7 @@ func WithCompetingActivity(name string) PresenceOpt {
 
 func withActivity(activity discord.Activity) PresenceOpt {
 	return func(presence *MessageDataPresenceUpdate) {
-		presence.Activities = append(presence.Activities, activity)
+		presence.Activities = []discord.Activity{activity}
 	}
 }
 

--- a/gateway/gateway_messages.go
+++ b/gateway/gateway_messages.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/json"
@@ -487,16 +486,18 @@ func withActivity(activity discord.Activity) PresenceOpt {
 func WithOnlineStatus(status discord.OnlineStatus) PresenceOpt {
 	return func(presence *MessageDataPresenceUpdate) {
 		presence.Status = status
-		if status == discord.OnlineStatusIdle {
-			since := time.Now().Unix()
-			presence.Since = &since
-		}
 	}
 }
 
 func WithAfk(afk bool) PresenceOpt {
 	return func(presence *MessageDataPresenceUpdate) {
 		presence.AFK = afk
+	}
+}
+
+func WithSince(since *int64) PresenceOpt {
+	return func(presence *MessageDataPresenceUpdate) {
+		presence.Since = since
 	}
 }
 

--- a/gateway/gateway_messages.go
+++ b/gateway/gateway_messages.go
@@ -437,6 +437,8 @@ type IdentifyCommandDataProperties struct {
 	Device  string `json:"device"`  // library name
 }
 
+type PresenceOpt func(presenceUpdate *MessageDataPresenceUpdate)
+
 func WithPlayingActivity(name string) PresenceOpt {
 	return withActivity(discord.Activity{
 		Name: name,


### PR DESCRIPTION
this PR changes presence data to be optional, resulting in not having to pass unwanted data.

before:
```go
bot.WithGatewayConfigOpts(
			gateway.WithIntents(gateway.IntentsNone),
			gateway.WithPresence(gateway.NewListeningPresence("music", discord.OnlineStatusOnline, false)),
)
```
after:
```go
// this yields the same result as the example above
bot.WithGatewayConfigOpts(
			gateway.WithIntents(gateway.IntentsNone),
			gateway.WithPresenceOpts(gateway.WithListeningActivity("music")),
)
```