### PR TITLE
replace UpdateSelfNick with UpdateCurrentMember

### DIFF
--- a/discord/member.go
+++ b/discord/member.go
@@ -85,5 +85,5 @@ type MemberUpdate struct {
 
 // CurrentMemberUpdate is used to update the current member
 type CurrentMemberUpdate struct {
-	Nick *string `json:"nick"`
+	Nick string `json:"nick"`
 }

--- a/discord/member.go
+++ b/discord/member.go
@@ -83,7 +83,7 @@ type MemberUpdate struct {
 	CommunicationDisabledUntil *json.Nullable[time.Time] `json:"communication_disabled_until,omitempty"`
 }
 
-// CurrentMemberUpdate is used to update your own member
+// CurrentMemberUpdate is used to update the current member
 type CurrentMemberUpdate struct {
 	Nick *string `json:"nick"`
 }

--- a/discord/member.go
+++ b/discord/member.go
@@ -83,7 +83,7 @@ type MemberUpdate struct {
 	CommunicationDisabledUntil *json.Nullable[time.Time] `json:"communication_disabled_until,omitempty"`
 }
 
-// SelfNickUpdate is used to update your own nick
-type SelfNickUpdate struct {
-	Nick string `json:"nick"`
+// CurrentMemberUpdate is used to update your own member
+type CurrentMemberUpdate struct {
+	Nick *string `json:"nick"`
 }

--- a/rest/members.go
+++ b/rest/members.go
@@ -22,7 +22,7 @@ type Members interface {
 	AddMemberRole(guildID snowflake.ID, userID snowflake.ID, roleID snowflake.ID, opts ...RequestOpt) error
 	RemoveMemberRole(guildID snowflake.ID, userID snowflake.ID, roleID snowflake.ID, opts ...RequestOpt) error
 
-	UpdateSelfNick(guildID snowflake.ID, nick string, opts ...RequestOpt) (*string, error)
+	UpdateCurrentMember(guildID snowflake.ID, nick *string, opts ...RequestOpt) (*string, error)
 
 	UpdateCurrentUserVoiceState(guildID snowflake.ID, currentUserVoiceStateUpdate discord.UserVoiceStateUpdate, opts ...RequestOpt) error
 	UpdateUserVoiceState(guildID snowflake.ID, userID snowflake.ID, userVoiceStateUpdate discord.UserVoiceStateUpdate, opts ...RequestOpt) error
@@ -95,8 +95,8 @@ func (s *memberImpl) RemoveMemberRole(guildID snowflake.ID, userID snowflake.ID,
 	return s.client.Do(RemoveMemberRole.Compile(nil, guildID, userID, roleID), nil, nil, opts...)
 }
 
-func (s *memberImpl) UpdateSelfNick(guildID snowflake.ID, nick string, opts ...RequestOpt) (nickName *string, err error) {
-	err = s.client.Do(UpdateSelfNick.Compile(nil, guildID), discord.SelfNickUpdate{Nick: nick}, nickName, opts...)
+func (s *memberImpl) UpdateCurrentMember(guildID snowflake.ID, nick *string, opts ...RequestOpt) (nickName *string, err error) {
+	err = s.client.Do(UpdateCurrentMember.Compile(nil, guildID), discord.CurrentMemberUpdate{Nick: nick}, nickName, opts...)
 	return
 }
 

--- a/rest/members.go
+++ b/rest/members.go
@@ -22,7 +22,7 @@ type Members interface {
 	AddMemberRole(guildID snowflake.ID, userID snowflake.ID, roleID snowflake.ID, opts ...RequestOpt) error
 	RemoveMemberRole(guildID snowflake.ID, userID snowflake.ID, roleID snowflake.ID, opts ...RequestOpt) error
 
-	UpdateCurrentMember(guildID snowflake.ID, nick *string, opts ...RequestOpt) (*string, error)
+	UpdateCurrentMember(guildID snowflake.ID, nick string, opts ...RequestOpt) (*string, error)
 
 	UpdateCurrentUserVoiceState(guildID snowflake.ID, currentUserVoiceStateUpdate discord.UserVoiceStateUpdate, opts ...RequestOpt) error
 	UpdateUserVoiceState(guildID snowflake.ID, userID snowflake.ID, userVoiceStateUpdate discord.UserVoiceStateUpdate, opts ...RequestOpt) error
@@ -95,7 +95,7 @@ func (s *memberImpl) RemoveMemberRole(guildID snowflake.ID, userID snowflake.ID,
 	return s.client.Do(RemoveMemberRole.Compile(nil, guildID, userID, roleID), nil, nil, opts...)
 }
 
-func (s *memberImpl) UpdateCurrentMember(guildID snowflake.ID, nick *string, opts ...RequestOpt) (nickName *string, err error) {
+func (s *memberImpl) UpdateCurrentMember(guildID snowflake.ID, nick string, opts ...RequestOpt) (nickName *string, err error) {
 	err = s.client.Do(UpdateCurrentMember.Compile(nil, guildID), discord.CurrentMemberUpdate{Nick: nick}, nickName, opts...)
 	return
 }

--- a/rest/rest_endpoints.go
+++ b/rest/rest_endpoints.go
@@ -73,7 +73,7 @@ var (
 	AddMemberRole    = NewEndpoint(http.MethodPut, "/guilds/{guild.id}/members/{user.id}/roles/{role.id}")
 	RemoveMemberRole = NewEndpoint(http.MethodDelete, "/guilds/{guild.id}/members/{user.id}/roles/{role.id}")
 
-	UpdateSelfNick = NewEndpoint(http.MethodPatch, "/guilds/{guild.id}/members/@me/nick")
+	UpdateCurrentMember = NewEndpoint(http.MethodPatch, "/guilds/{guild.id}/members/@me")
 
 	GetPruneMembersCount = NewEndpoint(http.MethodGet, "/guilds/{guild.id}/prune")
 	PruneMembers         = NewEndpoint(http.MethodPost, "/guilds/{guild.id}/prune")


### PR DESCRIPTION
the [`Modify Current User Nick`](https://discord.com/developers/docs/resources/guild#modify-current-user-nick) endpoint is deprecated.