### PR TITLE
prevent event dispatcher goroutine from capturing only the last loop index when asynchronously handling events

### DIFF
--- a/bot/event_manager.go
+++ b/bot/event_manager.go
@@ -146,7 +146,7 @@ func (e *eventManagerImpl) DispatchEvent(event Event) {
 	defer e.eventListenerMu.Unlock()
 	for i := range e.config.EventListeners {
 		if e.config.AsyncEventsEnabled {
-			go func() {
+			go func(i int) {
 				defer func() {
 					if r := recover(); r != nil {
 						e.config.Logger.Errorf("recovered from panic in event listener: %+v\nstack: %s", r, string(debug.Stack()))
@@ -154,7 +154,7 @@ func (e *eventManagerImpl) DispatchEvent(event Event) {
 					}
 				}()
 				e.config.EventListeners[i].OnEvent(event)
-			}()
+			}(i)
 			continue
 		}
 		e.config.EventListeners[i].OnEvent(event)


### PR DESCRIPTION
When operating in async mode with `e.config.AsyncEventsEnabled == true` (configured via `bot.WithEventManagerConfigOpts(bot.WithAsyncEventsEnabled())` option in `disgo.New()` call) the goroutine dispatched from default `eventManagerImpl.DispatchEvent` method will capture only the last for loop index, thus only ever calling the latest registered event listener. 
Can be easily reproduced with the following example:

in main.go:
```golang
package main

import (
	"context"
	"fmt"
	"github.com/disgoorg/disgo"
	"github.com/disgoorg/disgo/bot"
	"github.com/disgoorg/disgo/events"
	"github.com/disgoorg/disgo/gateway"
	"os"
	"os/signal"
	"syscall"
	"time"
)

func main() {
	client, err := disgo.New(
		"token goes here",
		bot.WithGatewayConfigOpts(
			gateway.WithIntents(gateway.IntentGuilds, gateway.IntentGuildMessages, gateway.IntentMessageContent),
		),
		bot.WithEventManagerConfigOpts(bot.WithAsyncEventsEnabled()),
	)

	if err != nil {
		panic("failed creating client")
	}

	client.AddEventListeners(bot.NewListenerFunc(func(e *events.MessageCreate) {
		fmt.Println("got message in first listener")
	}))
	client.AddEventListeners(bot.NewListenerFunc(func(e *events.MessageCreate) {
		fmt.Println("got message in second listener")
	}))
	client.AddEventListeners(bot.NewListenerFunc(func(e *events.MessageCreate) {
		fmt.Println("got message in third listener")
	}))

	ctx, cancel := context.WithTimeout(context.Background(), time.Second * 10)
	defer cancel()

	if err := client.OpenGateway(ctx); err != nil {
		panic("failed opening gateway")
	}

	defer func () {
		cctx, ccancel := context.WithTimeout(context.Background(), time.Second * 10)
		defer ccancel()

		client.Close(cctx)
	}()

	stop := make(chan os.Signal, 1)
	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
	fmt.Printf("Got termination signal %s, gracefully exiting...\n", (<-stop).String())
}
```
in event_manager.go:
```golang
func (e *eventManagerImpl) DispatchEvent(event Event) {
	defer func() {
		if r := recover(); r != nil {
			e.config.Logger.Errorf("recovered from panic in event listener: %+v\nstack: %s", r, string(debug.Stack()))
			return
		}
	}()
	e.eventListenerMu.Lock()
	defer e.eventListenerMu.Unlock()
	for i := range e.config.EventListeners {
		if e.config.AsyncEventsEnabled {
			go func() {
				defer func() {
					if r := recover(); r != nil {
						e.config.Logger.Errorf("recovered from panic in event listener: %+v\nstack: %s", r, string(debug.Stack()))
						return
					}
				}()
				fmt.Printf("handling event %d, in loop, local index: %d\n", event.SequenceNumber(), i)
				e.config.EventListeners[i].OnEvent(event)
			}()
			continue
		}
		e.config.EventListeners[i].OnEvent(event)
	}
}
```

Output in stdout upon receiving a single message event:
```
handling event 11, in loop, local index: 2
handling event 11, in loop, local index: 2
handling event 11, in loop, local index: 2
got message in third listener
handling event 11, in loop, local index: 2
handling event 11, in loop, local index: 2
got message in third listener
handling event 11, in loop, local index: 2
got message in third listener
```
Output with changes suggested in this PR:
```
handling event 11, in loop, local index: 2
handling event 11, in loop, local index: 0
handling event 11, in loop, local index: 1
handling event 11, in loop, local index: 0
got message in first listener
handling event 11, in loop, local index: 1
got message in second listener
handling event 11, in loop, local index: 2
got message in third listener
```