### PR TITLE
Pass through logger from config.

### DIFF
--- a/oauth2/state_controller.go
+++ b/oauth2/state_controller.go
@@ -28,6 +28,7 @@ func NewStateController(opts ...StateControllerConfigOpt) StateController {
 	return &stateControllerImpl{
 		states:       states,
 		newStateFunc: config.NewStateFunc,
+		logger:       config.Logger,
 	}
 }
 


### PR DESCRIPTION
It appears 2fc89bc438ab907d22fb63f595ebc6ccf50bd02a added a new `Logger` to `StateControllerConfig`, however it was not passed through to the underlying `stateControllerImpl`. It is always `nil` as a result and `NewState`/`UseState` will always panic when called because of this.