### PR TITLE
Add TeamRole

### DIFF
--- a/discord/application.go
+++ b/discord/application.go
@@ -241,11 +241,10 @@ func (t Team) CreatedAt() time.Time {
 }
 
 type TeamMember struct {
-	MembershipState MembershipState   `json:"membership_state"`
-	Permissions     []TeamPermissions `json:"permissions"`
-	TeamID          snowflake.ID      `json:"team_id"`
-	User            User              `json:"user"`
-	Role            TeamRole          `json:"role"`
+	MembershipState MembershipState `json:"membership_state"`
+	TeamID          snowflake.ID    `json:"team_id"`
+	User            User            `json:"user"`
+	Role            TeamRole        `json:"role"`
 }
 
 type MembershipState int
@@ -253,12 +252,6 @@ type MembershipState int
 const (
 	MembershipStateInvited MembershipState = iota + 1
 	MembershipStateAccepted
-)
-
-type TeamPermissions string
-
-const (
-	TeamPermissionAdmin = "*"
 )
 
 type TeamRole string

--- a/discord/application.go
+++ b/discord/application.go
@@ -245,12 +245,13 @@ type TeamMember struct {
 	Permissions     []TeamPermissions `json:"permissions"`
 	TeamID          snowflake.ID      `json:"team_id"`
 	User            User              `json:"user"`
+	Role            TeamRole          `json:"role"`
 }
 
 type MembershipState int
 
 const (
-	MembershipStateInvited = iota + 1
+	MembershipStateInvited MembershipState = iota + 1
 	MembershipStateAccepted
 )
 
@@ -258,4 +259,12 @@ type TeamPermissions string
 
 const (
 	TeamPermissionAdmin = "*"
+)
+
+type TeamRole string
+
+const (
+	TeamRoleAdmin     TeamRole = "admin"
+	TeamRoleDeveloper TeamRole = "developer"
+	TeamRoleReadOnly  TeamRole = "read_only"
 )


### PR DESCRIPTION
we seem to have missed this somehow. also, imo, we should get rid of the `Permissions` field since it was removed and never documented properly in the first place: https://github.com/discord/discord-api-docs/pull/6372#discussion_r1304483584

- [x] https://github.com/discord/discord-api-docs/pull/6372
- [x] https://github.com/discord/discord-api-docs/pull/6384