### PR TITLE
fix `VoiceRegion.ID` type

### DIFF
--- a/discord/voice_region.go
+++ b/discord/voice_region.go
@@ -1,7 +1,5 @@
 package discord
 
-import "github.com/disgoorg/snowflake/v2"
-
 // VoiceRegion (https://discord.com/developers/docs/resources/voice#voice-region-object)
 type VoiceRegion struct {
 	ID         string       `json:"id"`

--- a/discord/voice_region.go
+++ b/discord/voice_region.go
@@ -4,7 +4,7 @@ import "github.com/disgoorg/snowflake/v2"
 
 // VoiceRegion (https://discord.com/developers/docs/resources/voice#voice-region-object)
 type VoiceRegion struct {
-	ID         snowflake.ID `json:"id"`
+	ID         string       `json:"id"`
 	Name       string       `json:"name"`
 	Vip        bool         `json:"vip"`
 	Optimal    bool         `json:"optimal"`


### PR DESCRIPTION
otherwise `rest.Voice.GetVoiceRegions` always fails
```python
>>> url = 'https://discord.com/api/v10/voice/regions'
>>> headers = {'Authorization': 'Bot ' + token}
>>> response = requests.get(url, headers=headers)
>>> response
<Response [200]>
>>> response.json()
[{'id': 'brazil', 'name': 'Brazil', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'hongkong', 'name': 'Hong Kong', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'india', 'name': 'India', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'japan', 'name': 'Japan', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'rotterdam', 'name': 'Rotterdam', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'russia', 'name': 'Russia', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'singapore', 'name': 'Singapore', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'southafrica', 'name': 'South Africa', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'sydney', 'name': 'Sydney', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'us-central', 'name': 'US Central', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'us-east', 'name': 'US East', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'us-south', 'name': 'US South', 'custom': False, 'deprecated': False, 'optimal': False}, {'id': 'us-west', 'name': 'US West', 'custom': False, 'deprecated': False, 'optimal': False}]
>>>
```