### PR TITLE
Handle group DMs (channels)

### DIFF
--- a/discord/channels_raw.go
+++ b/discord/channels_raw.go
@@ -15,6 +15,16 @@ type dmChannel struct {
 	LastPinTimestamp *time.Time    `json:"last_pin_timestamp"`
 }
 
+type groupDMChannel struct {
+	ID               snowflake.ID  `json:"id"`
+	Type             ChannelType   `json:"type"`
+	OwnerID          *snowflake.ID `json:"owner_id"`
+	Name             string        `json:"name"`
+	LastPinTimestamp *time.Time    `json:"last_pin_timestamp"`
+	LastMessageID    *snowflake.ID `json:"last_message_id"`
+	Icon             *string       `json:"icon"`
+}
+
 type guildTextChannel struct {
 	ID                         snowflake.ID          `json:"id"`
 	Type                       ChannelType           `json:"type"`


### PR DESCRIPTION
since we're not handling them and Discord now allows for interactions to be called within group DMs, unmarshalling those interactions currently fails.

<details>
<summary>Example payload</summary>

```json
{
   "version":1,
   "user":{
      "username":"redacted",
      "public_flags":4194560,
      "id":"",
      "global_name":"redacted",
      "discriminator":"0",
      "clan":null,
      "avatar_decoration_data":null,
      "avatar":"redacted"
   },
   "type":2,
   "token":"",
   "locale":"fr",
   "id":"",
   "entitlements":[
      
   ],
   "data":{
      "type":1,
      "name":"flag",
      "id":""
   },
   "context":2,
   "channel_id":"",
   "channel":{
      "type":3,
      "owner_id":"redacted",
      "name":"redacted",
      "last_pin_timestamp":"2024-05-20T22:06:59+00:00",
      "last_message_id":"",
      "id":"",
      "icon":"redacted",
      "flags":0
   },
   "authorizing_integration_owners":{
      "1":""
   },
   "application_id":"1007647563790417960",
   "app_permissions":"180224"
}
```
</details>