### PR TITLE
Build ButtonComponents instead of using the helper

### DIFF
--- a/discord/component.go
+++ b/discord/component.go
@@ -285,7 +285,7 @@ func NewDangerButton(label string, customID string) ButtonComponent {
 // NewLinkButton creates a new link ButtonComponent with ButtonStyleLink & the provided parameters
 func NewLinkButton(label string, url string) ButtonComponent {
 	return ButtonComponent{
-		Style: ButtonStylePrimary,
+		Style: ButtonStyleLink,
 		Label: label,
 		URL:   url,
 	}

--- a/discord/component.go
+++ b/discord/component.go
@@ -248,27 +248,47 @@ func NewButton(style ButtonStyle, label string, customID string, url string) But
 
 // NewPrimaryButton creates a new ButtonComponent with ButtonStylePrimary & the provided parameters
 func NewPrimaryButton(label string, customID string) ButtonComponent {
-	return NewButton(ButtonStylePrimary, label, customID, "")
+	return ButtonComponent{
+		Style:    ButtonStylePrimary,
+		Label:    label,
+		CustomID: customID,
+	}
 }
 
 // NewSecondaryButton creates a new ButtonComponent with ButtonStyleSecondary & the provided parameters
 func NewSecondaryButton(label string, customID string) ButtonComponent {
-	return NewButton(ButtonStyleSecondary, label, customID, "")
+	return ButtonComponent{
+		Style:    ButtonStyleSecondary,
+		Label:    label,
+		CustomID: customID,
+	}
 }
 
 // NewSuccessButton creates a new ButtonComponent with ButtonStyleSuccess & the provided parameters
 func NewSuccessButton(label string, customID string) ButtonComponent {
-	return NewButton(ButtonStyleSuccess, label, customID, "")
+	return ButtonComponent{
+		Style:    ButtonStyleSuccess,
+		Label:    label,
+		CustomID: customID,
+	}
 }
 
 // NewDangerButton creates a new ButtonComponent with ButtonStyleDanger & the provided parameters
 func NewDangerButton(label string, customID string) ButtonComponent {
-	return NewButton(ButtonStyleDanger, label, customID, "")
+	return ButtonComponent{
+		Style:    ButtonStyleDanger,
+		Label:    label,
+		CustomID: customID,
+	}
 }
 
 // NewLinkButton creates a new link ButtonComponent with ButtonStyleLink & the provided parameters
 func NewLinkButton(label string, url string) ButtonComponent {
-	return NewButton(ButtonStyleLink, label, "", url)
+	return ButtonComponent{
+		Style: ButtonStylePrimary,
+		Label: label,
+		URL:   url,
+	}
 }
 
 var (


### PR DESCRIPTION
with the most recent addition of [`ButtonStylePremium`](https://github.com/disgoorg/disgo/pull/359), therefore a growing number of fields on buttons, it doesn't make sense to keep passing [zero values](https://github.com/disgoorg/disgo/blob/feature/premium-button/discord/component.go#L241) to the convenience function - it's rather less convenient to [pass data you do not want](https://github.com/disgoorg/disgo/blob/feature/premium-button/discord/component.go#L278).