### PR TITLE
Make the Audit Log Change Key typed and add constants for its possible values

### DIFF
--- a/discord/audit_log.go
+++ b/discord/audit_log.go
@@ -8,9 +8,6 @@ import (
 // AuditLogEvent is an 8-bit unsigned integer representing an audit log event.
 type AuditLogEvent int
 
-// AuditLogChangeKey is a string representing a key in the audit log change object.
-type AuditLogChangeKey string
-
 const (
 	AuditLogEventGuildUpdate AuditLogEvent = 1
 )
@@ -124,6 +121,9 @@ const (
 	AuditLogHomeSettingsCreate AuditLogEvent = iota + 190
 	AuditLogHomeSettingsUpdate
 )
+
+// AuditLogChangeKey is a string representing a key in the audit log change object.
+type AuditLogChangeKey string
 
 const (
 	AuditLogChangeKeyAFKChannelID AuditLogChangeKey = "afk_channel_id"

--- a/discord/audit_log.go
+++ b/discord/audit_log.go
@@ -8,6 +8,9 @@ import (
 // AuditLogEvent is an 8-bit unsigned integer representing an audit log event.
 type AuditLogEvent int
 
+// AuditLogChangeKey is a string representing a key in the audit log change object.
+type AuditLogChangeKey string
+
 const (
 	AuditLogEventGuildUpdate AuditLogEvent = 1
 )
@@ -122,6 +125,102 @@ const (
 	AuditLogHomeSettingsUpdate
 )
 
+const (
+	AuditLogChangeKeyAFKChannelID AuditLogChangeKey = "afk_channel_id"
+	AuditLogChangeKeyAFKTimeout   AuditLogChangeKey = "afk_timeout"
+	// AuditLogChangeKeyAllow is sent when a role's permission overwrites changed (stringy int)
+	AuditLogChangeKeyAllow         AuditLogChangeKey = "allow"
+	AuditLogChangeKeyApplicationID AuditLogChangeKey = "application_id"
+	// AuditLogChangeKeyArchived is sent when a channel thread is archived/unarchived (bool)
+	AuditLogChangeKeyArchived AuditLogChangeKey = "archived"
+	AuditLogChangeKeyAsset    AuditLogChangeKey = "asset"
+	// AuditLogChangeKeyAutoArchiveDuration is sent when a thread's auto archive duration is changed (int)
+	AuditLogChangeKeyAutoArchiveDuration AuditLogChangeKey = "auto_archive_duration"
+	AuditLogChangeKeyAvailable           AuditLogChangeKey = "available"
+	AuditLogChangeKeyAvatarHash          AuditLogChangeKey = "avatar_hash"
+	AuditLogChangeKeyBannerHash          AuditLogChangeKey = "banner_hash"
+	AuditLogChangeKeyBitrate             AuditLogChangeKey = "bitrate"
+	AuditLogChangeKeyChannelID           AuditLogChangeKey = "channel_id"
+	AuditLogChangeKeyCode                AuditLogChangeKey = "code"
+	// AuditLogChangeKeyColor is sent when a role's color is changed (int)
+	AuditLogChangeKeyColor AuditLogChangeKey = "color"
+	// AuditLogChangeKeyCommunicationDisabledUntil is sent when a user's communication disabled until datetime is changed (stringy ISO8601 datetime)
+	AuditLogChangeKeyCommunicationDisabledUntil AuditLogChangeKey = "communication_disabled_until"
+	// AuditLogChangeKeyDeaf is sent when a user is set to be server deafened/undeafened (bool)
+	AuditLogChangeKeyDeaf                        AuditLogChangeKey = "deaf"
+	AuditLogChangeKeyDefaultAutoArchiveDuration  AuditLogChangeKey = "default_auto_archive_duration"
+	AuditLogChangeKeyDefaultMessageNotifications AuditLogChangeKey = "default_message_notifications"
+	// AuditLogChangeKeyDeny is sent when a role's permission overwrites changed (stringed int)
+	AuditLogChangeKeyDeny                  AuditLogChangeKey = "deny"
+	AuditLogChangeKeyDescription           AuditLogChangeKey = "description"
+	AuditLogChangeKeyDiscoverySplashHash   AuditLogChangeKey = "discovery_splash_hash"
+	AuditLogChangeKeyEnableEmoticons       AuditLogChangeKey = "enable_emoticons"
+	AuditLogChangeKeyEntityType            AuditLogChangeKey = "entity_type"
+	AuditLogChangeKeyExpireBehavior        AuditLogChangeKey = "expire_behavior"
+	AuditLogChangeKeyExpireGracePeriod     AuditLogChangeKey = "expire_grace_period"
+	AuditLogChangeKeyExplicitContentFilter AuditLogChangeKey = "explicit_content_filter"
+	AuditLogChangeKeyFormatType            AuditLogChangeKey = "format_type"
+	AuditLogChangeKeyGuildID               AuditLogChangeKey = "guild_id"
+	// AuditLogChangeKeyHoist is sent when a role is set to be displayed separately from online members (bool)
+	AuditLogChangeKeyHoist     AuditLogChangeKey = "hoist"
+	AuditLogChangeKeyIconHash  AuditLogChangeKey = "icon_hash"
+	AuditLogChangeKeyID        AuditLogChangeKey = "id"
+	AuditLogChangeKeyInvitable AuditLogChangeKey = "invitable"
+	AuditLogChangeKeyInviterID AuditLogChangeKey = "inviter_id"
+	AuditLogChangeKeyLocation  AuditLogChangeKey = "location"
+	// AuditLogChangeKeyLocked is sent when a channel thread is locked/unlocked (bool)
+	AuditLogChangeKeyLocked  AuditLogChangeKey = "locked"
+	AuditLogChangeKeyMaxAge  AuditLogChangeKey = "max_age"
+	AuditLogChangeKeyMaxUses AuditLogChangeKey = "max_uses"
+	// AuditLogChangeKeyMentionable is sent when a role changes its mentionable state (bool)
+	AuditLogChangeKeyMentionable AuditLogChangeKey = "mentionable"
+	AuditLogChangeKeyMFALevel    AuditLogChangeKey = "mfa_level"
+	// AuditLogChangeKeyMute is sent when a user is server muted/unmuted (bool)
+	AuditLogChangeKeyMute AuditLogChangeKey = "mute"
+	AuditLogChangeKeyName AuditLogChangeKey = "name"
+	// AuditLogChangeKeyNick is sent when a user's nickname is changed (string)
+	AuditLogChangeKeyNick AuditLogChangeKey = "nick"
+	AuditLogChangeKeyNSFW AuditLogChangeKey = "nsfw"
+	// AuditLogChangeKeyOwnerID is sent when owner id of a guild changed (snowflake.ID)
+	AuditLogChangeKeyOwnerID AuditLogChangeKey = "owner_id"
+	// AuditLogChangeKeyPermissionOverwrites is sent when a role's permission overwrites changed (string)
+	AuditLogChangeKeyPermissionOverwrites AuditLogChangeKey = "permission_overwrites"
+	// AuditLogChangeKeyPermissions is sent when a role's permissions changed (string)
+	AuditLogChangeKeyPermissions AuditLogChangeKey = "permissions"
+	// AuditLogChangeKeyPosition is sent when channel position changed (int)
+	AuditLogChangeKeyPosition               AuditLogChangeKey = "position"
+	AuditLogChangeKeyPreferredLocale        AuditLogChangeKey = "preferred_locale"
+	AuditLogChangeKeyPrivacyLevel           AuditLogChangeKey = "privacy_level"
+	AuditLogChangeKeyPruneDeleteDays        AuditLogChangeKey = "prune_delete_days"
+	AuditLogChangeKeyPublicUpdatesChannelID AuditLogChangeKey = "public_updates_channel_id"
+	AuditLogChangeKeyRateLimitPerUser       AuditLogChangeKey = "rate_limit_per_user"
+	AuditLogChangeKeyRegion                 AuditLogChangeKey = "region"
+	AuditLogChangeKeyRulesChannelID         AuditLogChangeKey = "rules_channel_id"
+	AuditLogChangeKeySplashHash             AuditLogChangeKey = "splash_hash"
+	AuditLogChangeKeyStatus                 AuditLogChangeKey = "status"
+	// AuditLogChangeKeySystemChannelID is sent when system channel id of a guild changed (snowflake.ID)
+	AuditLogChangeKeySystemChannelID AuditLogChangeKey = "system_channel_id"
+	AuditLogChangeKeyTags            AuditLogChangeKey = "tags"
+	AuditLogChangeKeyTemporary       AuditLogChangeKey = "temporary"
+	// AuditLogChangeKeyTopic is sent when channel topic changed (string)
+	AuditLogChangeKeyTopic        AuditLogChangeKey = "topic"
+	AuditLogChangeKeyType         AuditLogChangeKey = "type"
+	AuditLogChangeKeyUnicodeEmoji AuditLogChangeKey = "unicode_emoji"
+	// AuditLogChangeKeyUserLimit is sent when user limit of a voice channel changed (int)
+	AuditLogChangeKeyUserLimit     AuditLogChangeKey = "user_limit"
+	AuditLogChangeKeyUses          AuditLogChangeKey = "uses"
+	AuditLogChangeKeyVanityURLCode AuditLogChangeKey = "vanity_url_code"
+	// AuditLogChangeKeyVerificationLevel is sent when verification level of the server changed (int)
+	AuditLogChangeKeyVerificationLevel AuditLogChangeKey = "verification_level"
+	AuditLogChangeKeyWidgetChannelID   AuditLogChangeKey = "widget_channel_id"
+	// AuditLogChangeKeyWidgetEnabled is sent when a server widget is enabled/disabled (bool)
+	AuditLogChangeKeyWidgetEnabled AuditLogChangeKey = "widget_enabled"
+	// AuditLogChangeKeyRoleAdd is sent when roles are added to a user (array of discord.PartialRole JSON)
+	AuditLogChangeKeyRoleAdd AuditLogChangeKey = "$add"
+	// AuditLogChangeKeyRoleRemove is sent when roles are removed from a user (array of discord.PartialRole JSON)
+	AuditLogChangeKeyRoleRemove AuditLogChangeKey = "$remove"
+)
+
 // AuditLog (https://discord.com/developers/docs/resources/audit-log) These are logs of events that occurred, accessible via the Discord
 type AuditLog struct {
 	ApplicationCommands  []ApplicationCommand  `json:"application_commands"`
@@ -190,7 +289,7 @@ type AuditLogChange struct {
 	// OldValue is the old value of the key before the change as a json.RawMessage.
 	OldValue json.RawMessage `json:"old_value"`
 	// Key is the key of the change.
-	Key string `json:"key"`
+	Key AuditLogChangeKey `json:"key"`
 }
 
 // UnmarshalNewValue unmarshals the NewValue field into the provided type.


### PR DESCRIPTION
Changes `AuditLogChange.Key` to be `AuditLogChangeKey` instead of `string`, and adds constants for its valid values.

This should make it a bit easier to match desired keys, since they will be defined in the library.