### PR TITLE
Change GuildPrivateThreadCreate to have NonInvitable field instead of Invitable

### DIFF
--- a/discord/thread.go
+++ b/discord/thread.go
@@ -80,7 +80,7 @@ func (GuildPublicThreadCreate) Type() ChannelType {
 type GuildPrivateThreadCreate struct {
 	Name                string              `json:"name"`
 	AutoArchiveDuration AutoArchiveDuration `json:"auto_archive_duration,omitempty"`
-	NonInvitable        bool                `json:"-"`
+	Invitable           *bool               `json:"invitable,omitempty"`
 }
 
 func (c GuildPrivateThreadCreate) MarshalJSON() ([]byte, error) {
@@ -88,11 +88,9 @@ func (c GuildPrivateThreadCreate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Type ChannelType `json:"type"`
 		guildPrivateThreadCreate
-		Invitable bool `json:"invitable"`
 	}{
 		Type:                     c.Type(),
 		guildPrivateThreadCreate: guildPrivateThreadCreate(c),
-		Invitable:                !c.NonInvitable,
 	})
 }
 

--- a/discord/thread.go
+++ b/discord/thread.go
@@ -80,7 +80,7 @@ func (GuildPublicThreadCreate) Type() ChannelType {
 type GuildPrivateThreadCreate struct {
 	Name                string              `json:"name"`
 	AutoArchiveDuration AutoArchiveDuration `json:"auto_archive_duration,omitempty"`
-	Invitable           bool                `json:"invitable,omitempty"`
+	NonInvitable        bool                `json:"-"`
 }
 
 func (c GuildPrivateThreadCreate) MarshalJSON() ([]byte, error) {
@@ -88,9 +88,11 @@ func (c GuildPrivateThreadCreate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Type ChannelType `json:"type"`
 		guildPrivateThreadCreate
+		Invitable bool `json:"invitable"`
 	}{
 		Type:                     c.Type(),
 		guildPrivateThreadCreate: guildPrivateThreadCreate(c),
+		Invitable:                !c.NonInvitable,
 	})
 }
 


### PR DESCRIPTION
The current implementation has the field `Invitable` and the JSON annotation `omitempty`, which results in the field being omitted when it is false. Not explicitly setting an invitable state should result in it being invitable, and as such, having `NonInvitable` achieves this.