### PR TITLE
Implement "List Active Guild Threads"

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -384,3 +384,8 @@ type GuildPrune struct {
 type GuildPruneResult struct {
 	Pruned *int `json:"pruned"`
 }
+
+type GuildActiveThreads struct {
+	Threads []GuildThread  `json:"threads"`
+	Members []ThreadMember `json:"members"`
+}

--- a/rest/rest_endpoints.go
+++ b/rest/rest_endpoints.go
@@ -192,6 +192,7 @@ var (
 	GetPublicArchivedThreads        = NewEndpoint(http.MethodGet, "/channels/{channel.id}/threads/archived/public")
 	GetPrivateArchivedThreads       = NewEndpoint(http.MethodGet, "/channels/{channel.id}/threads/archived/private")
 	GetJoinedPrivateArchivedThreads = NewEndpoint(http.MethodGet, "/channels/{channel.id}/users/@me/threads/archived/private")
+	GetActiveGuildThreads           = NewEndpoint(http.MethodGet, "/guilds/{guild.id}/threads/active")
 )
 
 // Messages

--- a/rest/threads.go
+++ b/rest/threads.go
@@ -30,6 +30,7 @@ type Threads interface {
 	GetPublicArchivedThreads(channelID snowflake.ID, before time.Time, limit int, opts ...RequestOpt) (threads *discord.GetThreads, err error)
 	GetPrivateArchivedThreads(channelID snowflake.ID, before time.Time, limit int, opts ...RequestOpt) (threads *discord.GetThreads, err error)
 	GetJoinedPrivateArchivedThreads(channelID snowflake.ID, before time.Time, limit int, opts ...RequestOpt) (threads *discord.GetThreads, err error)
+	GetActiveGuildThreads(guildID snowflake.ID, opts ...RequestOpt) (*discord.GuildActiveThreads, error)
 }
 
 type threadImpl struct {
@@ -130,6 +131,11 @@ func (s *threadImpl) GetJoinedPrivateArchivedThreads(channelID snowflake.ID, bef
 		queryValues["limit"] = limit
 	}
 	err = s.client.Do(GetJoinedPrivateArchivedThreads.Compile(queryValues, channelID), nil, &threads, opts...)
+	return
+}
+
+func (s *threadImpl) GetActiveGuildThreads(guildID snowflake.ID, opts ...RequestOpt) (activeThreads *discord.GuildActiveThreads, err error) {
+	err = s.client.Do(GetActiveGuildThreads.Compile(nil, guildID), nil, &activeThreads, opts...)
 	return
 }
 


### PR DESCRIPTION
Creates a method that implements the [`/guilds/{guild.id}/threads/active`][ref] endpoint of the Discord API.


[ref]: https://discord.com/developers/docs/resources/guild#list-active-guild-threads