### PR TITLE
Add Acknowledge function to ApplicationCommandInteractionCreate for HTTP server interactions

### DIFF
--- a/discord/interaction_response.go
+++ b/discord/interaction_response.go
@@ -5,7 +5,9 @@ type InteractionResponseType int
 
 // Constants for the InteractionResponseType(s)
 const (
-	InteractionResponseTypePong InteractionResponseType = iota + 1
+	// This is stricly internal and will never be sent to discord. It is used to indicate that the HTTP response should be 202 Accepted
+	InteractionResponseTypeAcknowledge InteractionResponseType = iota
+	InteractionResponseTypePong        InteractionResponseType = iota
 	_
 	_
 	InteractionResponseTypeCreateMessage

--- a/discord/interaction_response.go
+++ b/discord/interaction_response.go
@@ -5,9 +5,12 @@ type InteractionResponseType int
 
 // Constants for the InteractionResponseType(s)
 const (
-	// This is stricly internal and will never be sent to discord. It is used to indicate that the HTTP response should be 202 Accepted
-	InteractionResponseTypeAcknowledge InteractionResponseType = iota
-	InteractionResponseTypePong        InteractionResponseType = iota
+	// InteractionResponseTypeAcknowledge is stricly internal and will never be sent to discord.
+	//
+	// It is used to indicate that the HTTP response should be 202 Accepted
+	InteractionResponseTypeAcknowledge InteractionResponseType = -1
+
+	InteractionResponseTypePong InteractionResponseType = iota + 1
 	_
 	_
 	InteractionResponseTypeCreateMessage

--- a/discord/interaction_response.go
+++ b/discord/interaction_response.go
@@ -3,13 +3,13 @@ package discord
 // InteractionResponseType indicates the type of slash command response, whether it's responding immediately or deferring to edit your response later
 type InteractionResponseType int
 
+// InteractionResponseTypeAcknowledge is stricly internal and will never be sent to discord.
+//
+// It is used to indicate that the HTTP response should be 202 Accepted
+const InteractionResponseTypeAcknowledge InteractionResponseType = -1
+
 // Constants for the InteractionResponseType(s)
 const (
-	// InteractionResponseTypeAcknowledge is stricly internal and will never be sent to discord.
-	//
-	// It is used to indicate that the HTTP response should be 202 Accepted
-	InteractionResponseTypeAcknowledge InteractionResponseType = -1
-
 	InteractionResponseTypePong InteractionResponseType = iota + 1
 	_
 	_

--- a/events/interaction_events.go
+++ b/events/interaction_events.go
@@ -47,6 +47,8 @@ func (e *ApplicationCommandInteractionCreate) Guild() (discord.Guild, bool) {
 // This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
 //
 // This does not produce a visible loading state to the user.
+// You are expected to send a new http request within 3 seconds to respond to the interaction.
+// This allows you to gracefully handle errors with your sent response & access the resulting message.
 // If you want to create a visible loading state, use DeferCreateMessage.
 //
 // Source docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback

--- a/events/interaction_events.go
+++ b/events/interaction_events.go
@@ -42,6 +42,18 @@ func (e *ApplicationCommandInteractionCreate) Guild() (discord.Guild, bool) {
 	return discord.Guild{}, false
 }
 
+// Acknowledge acknowledges the interaction.
+//
+// This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
+//
+// This does not produce a visible loading state to the user.
+// If you want to create a visible loading state, use DeferCreateMessage.
+//
+// Source docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
+func (e *ApplicationCommandInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
+	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
+}
+
 // CreateMessage responds to the interaction with a new message.
 func (e *ApplicationCommandInteractionCreate) CreateMessage(messageCreate discord.MessageCreate, opts ...rest.RequestOpt) error {
 	return e.Respond(discord.InteractionResponseTypeCreateMessage, messageCreate, opts...)

--- a/events/interaction_events.go
+++ b/events/interaction_events.go
@@ -56,8 +56,6 @@ func (e *ApplicationCommandInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // Source docs: [Discord Source docs]
 //
-// [rest.Interactions.CreateInteractionResponse]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponse
-// [rest.Interactions.CreateInteractionResponseWithCallback]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponseWithCallback
 // [Discord Source docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
 func (e *ApplicationCommandInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
 	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
@@ -124,8 +122,6 @@ func (e *ComponentInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // Source docs: [Discord Source docs]
 //
-// [rest.Interactions.CreateInteractionResponse]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponse
-// [rest.Interactions.CreateInteractionResponseWithCallback]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponseWithCallback
 // [Discord Source docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
 func (e *ComponentInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
 	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
@@ -224,8 +220,6 @@ func (e *ModalSubmitInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // Source docs: [Discord Source docs]
 //
-// [rest.Interactions.CreateInteractionResponse]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponse
-// [rest.Interactions.CreateInteractionResponseWithCallback]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponseWithCallback
 // [Discord Source docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
 func (e *ModalSubmitInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
 	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)

--- a/events/interaction_events.go
+++ b/events/interaction_events.go
@@ -46,7 +46,7 @@ func (e *ApplicationCommandInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
 //
-// When using this, your first http request must be <event>.Client().Rest().CreateInteractionResponse()
+// When using this, your first http request must be [rest.Interactions.CreateInteractionResponse] or [rest.Interactions.CreateInteractionResponseWithCallback]
 //
 // This does not produce a visible loading state to the user.
 // You are expected to send a new http request within 3 seconds to respond to the interaction.
@@ -54,7 +54,11 @@ func (e *ApplicationCommandInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // If you want to create a visible loading state, use DeferCreateMessage.
 //
-// Source docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
+// Source docs: [Discord Source docs]
+//
+// [rest.Interactions.CreateInteractionResponse]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponse
+// [rest.Interactions.CreateInteractionResponseWithCallback]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponseWithCallback
+// [Discord Source docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
 func (e *ApplicationCommandInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
 	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
 }
@@ -110,7 +114,7 @@ func (e *ComponentInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
 //
-// When using this, your first http request must be <event>.Client().Rest().CreateInteractionResponse()
+// When using this, your first http request must be [rest.Interactions.CreateInteractionResponse] or [rest.Interactions.CreateInteractionResponseWithCallback]
 //
 // This does not produce a visible loading state to the user.
 // You are expected to send a new http request within 3 seconds to respond to the interaction.
@@ -118,7 +122,11 @@ func (e *ComponentInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // If you want to create a visible loading state, use DeferCreateMessage.
 //
-// Source docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
+// Source docs: [Discord Source docs]
+//
+// [rest.Interactions.CreateInteractionResponse]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponse
+// [rest.Interactions.CreateInteractionResponseWithCallback]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponseWithCallback
+// [Discord Source docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
 func (e *ComponentInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
 	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
 }
@@ -206,7 +214,7 @@ func (e *ModalSubmitInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
 //
-// When using this, your first http request must be <event>.Client().Rest().CreateInteractionResponse()
+// When using this, your first http request must be [rest.Interactions.CreateInteractionResponse] or [rest.Interactions.CreateInteractionResponseWithCallback]
 //
 // This does not produce a visible loading state to the user.
 // You are expected to send a new http request within 3 seconds to respond to the interaction.
@@ -214,7 +222,11 @@ func (e *ModalSubmitInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // If you want to create a visible loading state, use DeferCreateMessage.
 //
-// Source docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
+// Source docs: [Discord Source docs]
+//
+// [rest.Interactions.CreateInteractionResponse]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponse
+// [rest.Interactions.CreateInteractionResponseWithCallback]: https://pkg.go.dev/github.com/disgoorg/disgo/rest#Interactions.CreateInteractionResponseWithCallback
+// [Discord Source docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
 func (e *ModalSubmitInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
 	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
 }

--- a/events/interaction_events.go
+++ b/events/interaction_events.go
@@ -46,7 +46,7 @@ func (e *ApplicationCommandInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
 //
-// When using this, you must respond with <event>.Client().Rest().CreateInteractionResponse()
+// When using this, your first http request must be <event>.Client().Rest().CreateInteractionResponse()
 //
 // This does not produce a visible loading state to the user.
 // You are expected to send a new http request within 3 seconds to respond to the interaction.
@@ -110,7 +110,7 @@ func (e *ComponentInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
 //
-// When using this, you must respond with <event>.Client().Rest().CreateInteractionResponse()
+// When using this, your first http request must be <event>.Client().Rest().CreateInteractionResponse()
 //
 // This does not produce a visible loading state to the user.
 // You are expected to send a new http request within 3 seconds to respond to the interaction.
@@ -206,7 +206,7 @@ func (e *ModalSubmitInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
 //
-// When using this, you must respond with <event>.Client().Rest().CreateInteractionResponse()
+// When using this, your first http request must be <event>.Client().Rest().CreateInteractionResponse()
 //
 // This does not produce a visible loading state to the user.
 // You are expected to send a new http request within 3 seconds to respond to the interaction.

--- a/events/interaction_events.go
+++ b/events/interaction_events.go
@@ -184,6 +184,25 @@ func (e *AutocompleteInteractionCreate) Guild() (discord.Guild, bool) {
 	return discord.Guild{}, false
 }
 
+// Acknowledge acknowledges the interaction.
+//
+// This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
+//
+// When using this, your first http request must be [rest.Interactions.CreateInteractionResponse] or [rest.Interactions.CreateInteractionResponseWithCallback]
+//
+// This does not produce a visible loading state to the user.
+// You are expected to send a new http request within 3 seconds to respond to the interaction.
+// This allows you to gracefully handle errors with your sent response & access the resulting message.
+//
+// If you want to create a visible loading state, use DeferCreateMessage.
+//
+// Source docs: [Discord Source docs]
+//
+// [Discord Source docs]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
+func (e *AutocompleteInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
+	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
+}
+
 // AutocompleteResult responds to the interaction with a slice of choices.
 func (e *AutocompleteInteractionCreate) AutocompleteResult(choices []discord.AutocompleteChoice, opts ...rest.RequestOpt) error {
 	return e.Respond(discord.InteractionResponseTypeAutocompleteResult, discord.AutocompleteResult{Choices: choices}, opts...)

--- a/events/interaction_events.go
+++ b/events/interaction_events.go
@@ -46,9 +46,12 @@ func (e *ApplicationCommandInteractionCreate) Guild() (discord.Guild, bool) {
 //
 // This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
 //
+// When using this, you must respond with <event>.Client().Rest().CreateInteractionResponse()
+//
 // This does not produce a visible loading state to the user.
 // You are expected to send a new http request within 3 seconds to respond to the interaction.
 // This allows you to gracefully handle errors with your sent response & access the resulting message.
+//
 // If you want to create a visible loading state, use DeferCreateMessage.
 //
 // Source docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
@@ -101,6 +104,23 @@ func (e *ComponentInteractionCreate) Guild() (discord.Guild, bool) {
 		return e.Client().Caches().Guild(*e.GuildID())
 	}
 	return discord.Guild{}, false
+}
+
+// Acknowledge acknowledges the interaction.
+//
+// This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
+//
+// When using this, you must respond with <event>.Client().Rest().CreateInteractionResponse()
+//
+// This does not produce a visible loading state to the user.
+// You are expected to send a new http request within 3 seconds to respond to the interaction.
+// This allows you to gracefully handle errors with your sent response & access the resulting message.
+//
+// If you want to create a visible loading state, use DeferCreateMessage.
+//
+// Source docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
+func (e *ComponentInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
+	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
 }
 
 // CreateMessage responds to the interaction with a new message.
@@ -180,6 +200,23 @@ func (e *ModalSubmitInteractionCreate) Guild() (discord.Guild, bool) {
 		return e.Client().Caches().Guild(*e.GuildID())
 	}
 	return discord.Guild{}, false
+}
+
+// Acknowledge acknowledges the interaction.
+//
+// This is used strictly for acknowledging the HTTP interaction request from discord. This responds with 202 Accepted.
+//
+// When using this, you must respond with <event>.Client().Rest().CreateInteractionResponse()
+//
+// This does not produce a visible loading state to the user.
+// You are expected to send a new http request within 3 seconds to respond to the interaction.
+// This allows you to gracefully handle errors with your sent response & access the resulting message.
+//
+// If you want to create a visible loading state, use DeferCreateMessage.
+//
+// Source docs: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
+func (e *ModalSubmitInteractionCreate) Acknowledge(opts ...rest.RequestOpt) error {
+	return e.Respond(discord.InteractionResponseTypeAcknowledge, nil, opts...)
 }
 
 // CreateMessage responds to the interaction with a new message.

--- a/httpserver/server.go
+++ b/httpserver/server.go
@@ -167,6 +167,15 @@ func HandleInteraction(publicKey PublicKey, logger *slog.Logger, handleFunc Even
 		defer cancel()
 		select {
 		case response := <-responseChannel:
+
+			// if we only acknowledge the interaction, we don't need to send a response body
+			// we just need to send a 202 Accepted status
+			if response.Type == discord.InteractionResponseTypeAcknowledge {
+				w.WriteHeader(http.StatusAccepted)
+				w.Write(nil)
+				return
+			}
+
 			if body, err = response.ToBody(); err != nil {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				errorChannel <- err

--- a/httpserver/server.go
+++ b/httpserver/server.go
@@ -172,7 +172,6 @@ func HandleInteraction(publicKey PublicKey, logger *slog.Logger, handleFunc Even
 			// we just need to send a 202 Accepted status
 			if response.Type == discord.InteractionResponseTypeAcknowledge {
 				w.WriteHeader(http.StatusAccepted)
-				w.Write(nil)
 				return
 			}
 


### PR DESCRIPTION
This pull request introduces a new function to  `ApplicationCommandInteractionCreate`

`ApplicationCommandInteractionCreate.Acknowledge()`

### Additions:
#### New Interaction Response Type:
`InteractionResponseTypeAcknowledge`. A Strictly internal iota to identify this response type.

#### New function:
`ApplicationCommandInteractionCreate.Acknowledge()`. This method is used to respond to the original HTTP request from discord with StatusAccepted (202). 
This is not like `ApplicationCommandInteractionCreate.DeferCreateMessage()`. You are still required to respond with a new HTTP request within 3 seconds to respond to the interaction.
Unlike `ApplicationCommandInteractionCreate.CreateMessage()`, you are able to access the response which will contain error or the sent message when you send `event.Client().Rest().CreateInteractionResponse()`


Source to this can be found [here](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback)
`If you send this request for an interaction received over HTTP, respond to the original HTTP request with a 202 and no body.`

This is the preferred way to respond to Interactions as you can receive the message created in the response if u need it and errors.