### PR TITLE
fix: Use `OpenShardManager` in proxy example

### DIFF
--- a/_examples/proxy/example.go
+++ b/_examples/proxy/example.go
@@ -74,7 +74,7 @@ func main() {
 		return
 	}
 
-	if err = client.OpenGateway(context.TODO()); err != nil {
+	if err = client.OpenShardManager(context.TODO()); err != nil {
 		slog.Error("error while connecting to gateway", slog.Any("err", err))
 		return
 	}


### PR DESCRIPTION
Since the bot is configured with a shard manager (`bot.WithShardManagerConfigOpts`), `OpenShardManager` must be used instead of `OpenGateway`.