### PR TITLE
Replace GatewayGuild with UnavailableGuild in EventGuildDelete

### DIFF
--- a/gateway/gateway_events.go
+++ b/gateway/gateway_events.go
@@ -214,7 +214,7 @@ func (EventGuildUpdate) messageData() {}
 func (EventGuildUpdate) eventData()   {}
 
 type EventGuildDelete struct {
-	discord.GatewayGuild
+	discord.UnavailableGuild
 }
 
 func (EventGuildDelete) messageData() {}


### PR DESCRIPTION
The inner payload of a guild delete event is an unavailable guild: https://discord.com/developers/docs/events/gateway-events#guild-delete