### PR TITLE
Dispatch EventRaw even if its type is unknown

### DIFF
--- a/gateway/gateway_impl.go
+++ b/gateway/gateway_impl.go
@@ -406,17 +406,17 @@ loop:
 				g.config.Logger.Debug("ready message received")
 			}
 
-			if unknownEvent, ok := eventData.(EventUnknown); ok {
-				g.config.Logger.Debug("unknown event received", slog.String("event", string(message.T)), slog.String("data", string(unknownEvent)))
-				continue
-			}
-
 			// push message to the command manager
 			if g.config.EnableRawEvents {
 				g.eventHandlerFunc(EventTypeRaw, message.S, g.config.ShardID, EventRaw{
 					EventType: message.T,
 					Payload:   bytes.NewReader(message.RawD),
 				})
+			}
+
+			if unknownEvent, ok := eventData.(EventUnknown); ok {
+				g.config.Logger.Debug("unknown event received", slog.String("event", string(message.T)), slog.String("data", string(unknownEvent)))
+				continue
 			}
 			g.eventHandlerFunc(message.T, message.S, g.config.ShardID, eventData)
 


### PR DESCRIPTION
This is useful in a gateway proxy for example, where an event should be handled even if Disgo doesn't know about it.