### PR TITLE
Fix incorrect initialization of shard IDs in `BuildClient`

### DIFF
--- a/bot/config.go
+++ b/bot/config.go
@@ -282,7 +282,7 @@ func BuildClient(token string, cfg *Config, gatewayEventHandlerFunc func(client 
 		}
 
 		shardIDs := make([]int, gatewayBotRs.Shards)
-		for i := 0; i < gatewayBotRs.Shards-1; i++ {
+		for i := 0; i < gatewayBotRs.Shards; i++ {
 			shardIDs[i] = i
 		}
 


### PR DESCRIPTION
Fixes a off-by-one error when initializing shardIDs the `BuildClient`.

Currently, if `gatewayBotRs.Shards` is 5, then shardIDs first gets initialized to:
```go
{0,0,0,0,0}
```

Then, the loop iterates up to `gatewayBotRs.Shards-1`,  skipping the fourth shard:
```go
{0,1,2,3,0}
```