### PR TITLE
Fix JoinSnowflakes trailing or missing comma

### DIFF
--- a/internal/slicehelper/slice_helper.go
+++ b/internal/slicehelper/slice_helper.go
@@ -1,14 +1,15 @@
 package slicehelper
 
-import "github.com/disgoorg/snowflake/v2"
+import (
+	"strings"
+
+	"github.com/disgoorg/snowflake/v2"
+)
 
 func JoinSnowflakes(snowflakes []snowflake.ID) string {
-	var str string
+	strs := make([]string, len(snowflakes))
 	for i, s := range snowflakes {
-		str += s.String()
-		if i != len(str)-1 {
-			str += ","
-		}
+		strs[i] = s.String()
 	}
-	return str
+	return strings.Join(strs, ",")
 }


### PR DESCRIPTION
The current implemention incorrectly checks the length of the accumulated string instead of the slice when appending a comma. This usually results in a trailing comma or even missing commas.