### PR TITLE
sharding: Fix data race in shard rate limiter

### DIFF
--- a/sharding/shard_rate_limiter.go
+++ b/sharding/shard_rate_limiter.go
@@ -18,6 +18,7 @@ type RateLimiter interface {
 	WaitBucket(ctx context.Context, shardID int) error
 
 	// UnlockBucket unlocks the given shardID bucket.
+	// If WaitBucket fails, UnlockBucket should not be called.
 	UnlockBucket(shardID int)
 }
 

--- a/sharding/shard_rate_limiter_config.go
+++ b/sharding/shard_rate_limiter_config.go
@@ -10,7 +10,7 @@ func DefaultRateLimiterConfig() *RateLimiterConfig {
 	return &RateLimiterConfig{
 		Logger:         slog.Default(),
 		MaxConcurrency: MaxConcurrency,
-		identifyWait:   5 * time.Second,
+		IdentifyWait:   5 * time.Second,
 	}
 }
 
@@ -18,7 +18,7 @@ func DefaultRateLimiterConfig() *RateLimiterConfig {
 type RateLimiterConfig struct {
 	Logger         *slog.Logger
 	MaxConcurrency int
-	identifyWait   time.Duration
+	IdentifyWait   time.Duration
 }
 
 // RateLimiterConfigOpt is a type alias for a function that takes a RateLimiterConfig and is used to configure your Server.
@@ -45,9 +45,9 @@ func WithMaxConcurrency(maxConcurrency int) RateLimiterConfigOpt {
 	}
 }
 
-// withIdentifyWait sets the duration to wait in between identifying shards.
-func withIdentifyWait(identifyWait time.Duration) RateLimiterConfigOpt {
+// WithIdentifyWait sets the duration to wait in between identifying shards.
+func WithIdentifyWait(identifyWait time.Duration) RateLimiterConfigOpt {
 	return func(config *RateLimiterConfig) {
-		config.identifyWait = identifyWait
+		config.IdentifyWait = identifyWait
 	}
 }

--- a/sharding/shard_rate_limiter_config.go
+++ b/sharding/shard_rate_limiter_config.go
@@ -2,6 +2,7 @@ package sharding
 
 import (
 	"log/slog"
+	"time"
 )
 
 // DefaultRateLimiterConfig returns a RateLimiterConfig with sensible defaults.
@@ -9,6 +10,7 @@ func DefaultRateLimiterConfig() *RateLimiterConfig {
 	return &RateLimiterConfig{
 		Logger:         slog.Default(),
 		MaxConcurrency: MaxConcurrency,
+		identifyWait:   5 * time.Second,
 	}
 }
 
@@ -16,6 +18,7 @@ func DefaultRateLimiterConfig() *RateLimiterConfig {
 type RateLimiterConfig struct {
 	Logger         *slog.Logger
 	MaxConcurrency int
+	identifyWait   time.Duration
 }
 
 // RateLimiterConfigOpt is a type alias for a function that takes a RateLimiterConfig and is used to configure your Server.
@@ -39,5 +42,12 @@ func WithRateLimiterLogger(logger *slog.Logger) RateLimiterConfigOpt {
 func WithMaxConcurrency(maxConcurrency int) RateLimiterConfigOpt {
 	return func(config *RateLimiterConfig) {
 		config.MaxConcurrency = maxConcurrency
+	}
+}
+
+// withIdentifyWait sets the duration to wait in between identifying shards.
+func withIdentifyWait(identifyWait time.Duration) RateLimiterConfigOpt {
+	return func(config *RateLimiterConfig) {
+		config.identifyWait = identifyWait
 	}
 }

--- a/sharding/shard_rate_limiter_impl.go
+++ b/sharding/shard_rate_limiter_impl.go
@@ -9,9 +9,6 @@ import (
 	"github.com/sasha-s/go-csync"
 )
 
-// identifyWait is the duration to wait in between identifying shards.
-var identifyWait = 5 * time.Second
-
 var _ RateLimiter = (*rateLimiterImpl)(nil)
 
 // NewRateLimiter creates a new default RateLimiter with the given RateLimiterConfigOpt(s).
@@ -98,7 +95,7 @@ func (r *rateLimiterImpl) WaitBucket(ctx context.Context, shardID int) error {
 func (r *rateLimiterImpl) UnlockBucket(shardID int) {
 	b := r.getBucket(shardID)
 
-	b.reset = time.Now().Add(identifyWait)
+	b.reset = time.Now().Add(r.config.identifyWait)
 	r.config.Logger.Debug("unlocking shard bucket", slog.Int("key", b.key), slog.Time("reset", b.reset))
 	b.mu.Unlock()
 }

--- a/sharding/shard_rate_limiter_impl.go
+++ b/sharding/shard_rate_limiter_impl.go
@@ -95,7 +95,7 @@ func (r *rateLimiterImpl) WaitBucket(ctx context.Context, shardID int) error {
 func (r *rateLimiterImpl) UnlockBucket(shardID int) {
 	b := r.getBucket(shardID)
 
-	b.reset = time.Now().Add(r.config.identifyWait)
+	b.reset = time.Now().Add(r.config.IdentifyWait)
 	r.config.Logger.Debug("unlocking shard bucket", slog.Int("key", b.key), slog.Time("reset", b.reset))
 	b.mu.Unlock()
 }

--- a/sharding/shard_rate_limiter_impl_test.go
+++ b/sharding/shard_rate_limiter_impl_test.go
@@ -12,7 +12,7 @@ import (
 func TestShardRateLimiterImpl(t *testing.T) {
 	t.Parallel()
 
-	r := NewRateLimiter(withIdentifyWait(100 * time.Millisecond))
+	r := NewRateLimiter(WithIdentifyWait(100 * time.Millisecond))
 
 	start := time.Now()
 
@@ -36,7 +36,7 @@ func TestShardRateLimiterImpl(t *testing.T) {
 func TestShardRateLimiterImpl_WithMaxConcurrency(t *testing.T) {
 	t.Parallel()
 
-	r := NewRateLimiter(WithMaxConcurrency(3), withIdentifyWait(100*time.Millisecond))
+	r := NewRateLimiter(WithMaxConcurrency(3), WithIdentifyWait(100*time.Millisecond))
 
 	start := time.Now()
 

--- a/sharding/shard_rate_limiter_impl_test.go
+++ b/sharding/shard_rate_limiter_impl_test.go
@@ -1,0 +1,81 @@
+package sharding
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	identifyWait = 100 * time.Millisecond
+}
+
+func TestShardRateLimiterImpl(t *testing.T) {
+	t.Parallel()
+
+	r := NewRateLimiter()
+
+	start := time.Now()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		shardID := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := r.WaitBucket(context.Background(), shardID)
+			assert.NoError(t, err)
+			r.UnlockBucket(shardID)
+		}()
+	}
+	wg.Wait()
+
+	expected := start.Add(200 * time.Millisecond)
+	assert.WithinDuration(t, expected, time.Now(), 10*time.Millisecond)
+}
+
+func TestShardRateLimiterImpl_WithMaxConcurrency(t *testing.T) {
+	t.Parallel()
+
+	r := NewRateLimiter(WithMaxConcurrency(3))
+
+	start := time.Now()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 6; i++ {
+		shardID := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := r.WaitBucket(context.Background(), shardID)
+			assert.NoError(t, err)
+			r.UnlockBucket(shardID)
+		}()
+	}
+	wg.Wait()
+
+	expected := start.Add(100 * time.Millisecond)
+	assert.WithinDuration(t, expected, time.Now(), 10*time.Millisecond)
+}
+
+func TestShardRateLimiterImpl_WaitBucketWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	r := NewRateLimiter()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := r.WaitBucket(ctx, 0)
+	assert.NoError(t, err)
+
+	err = r.WaitBucket(ctx, 0)
+	if assert.Error(t, err) {
+		assert.Equal(t, context.DeadlineExceeded, err)
+	}
+
+	r.UnlockBucket(0)
+}

--- a/sharding/shard_rate_limiter_impl_test.go
+++ b/sharding/shard_rate_limiter_impl_test.go
@@ -9,14 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	identifyWait = 100 * time.Millisecond
-}
-
 func TestShardRateLimiterImpl(t *testing.T) {
 	t.Parallel()
 
-	r := NewRateLimiter()
+	r := NewRateLimiter(withIdentifyWait(100 * time.Millisecond))
 
 	start := time.Now()
 
@@ -40,7 +36,7 @@ func TestShardRateLimiterImpl(t *testing.T) {
 func TestShardRateLimiterImpl_WithMaxConcurrency(t *testing.T) {
 	t.Parallel()
 
-	r := NewRateLimiter(WithMaxConcurrency(3))
+	r := NewRateLimiter(WithMaxConcurrency(3), withIdentifyWait(100*time.Millisecond))
 
 	start := time.Now()
 


### PR DESCRIPTION
Fixes a data race (due to concurrent access of `bucket.reset`) and adds some tests