### PR TITLE
handlers: Provide full GatewayGuild object on guild create events

### DIFF
--- a/events/guild_events.go
+++ b/events/guild_events.go
@@ -6,42 +6,47 @@ import (
 	"github.com/disgoorg/disgo/discord"
 )
 
-// GenericGuild is called upon receiving GuildUpdate , GuildAvailable , GuildUnavailable , GuildJoin , GuildLeave , GuildReady , GuildBan , GuildUnban
+// GenericGuild represents a generic guild event
 type GenericGuild struct {
 	*GenericEvent
 	GuildID snowflake.ID
-	Guild   discord.Guild
 }
 
 // GuildUpdate is called upon receiving discord.Guild updates
 type GuildUpdate struct {
 	*GenericGuild
-	OldGuild discord.Guild
+	Guild    discord.Guild
+	OldGuild discord.Guild // the old cached guild
 }
 
 // GuildAvailable is called when an unavailable discord.Guild becomes available
 type GuildAvailable struct {
 	*GenericGuild
+	Guild discord.GatewayGuild
 }
 
 // GuildUnavailable is called when an available discord.Guild becomes unavailable
 type GuildUnavailable struct {
 	*GenericGuild
+	Guild discord.Guild // the old cached guild
 }
 
 // GuildJoin is called when the bot joins a discord.Guild
 type GuildJoin struct {
 	*GenericGuild
+	Guild discord.GatewayGuild
 }
 
 // GuildLeave is called when the bot leaves a discord.Guild
 type GuildLeave struct {
 	*GenericGuild
+	Guild discord.Guild // the old cached guild
 }
 
 // GuildReady is called when a discord.Guild becomes loaded for the first time
 type GuildReady struct {
 	*GenericGuild
+	Guild discord.GatewayGuild
 }
 
 // GuildsReady is called when all discord.Guild(s) are loaded after logging in
@@ -51,21 +56,18 @@ type GuildsReady struct {
 
 // GuildBan is called when a discord.Member/discord.User is banned from the discord.Guild
 type GuildBan struct {
-	*GenericEvent
-	GuildID snowflake.ID
-	User    discord.User
+	*GenericGuild
+	User discord.User
 }
 
 // GuildUnban is called when a discord.Member/discord.User is unbanned from the discord.Guild
 type GuildUnban struct {
-	*GenericEvent
-	GuildID snowflake.ID
-	User    discord.User
+	*GenericGuild
+	User discord.User
 }
 
 // GuildAuditLogEntryCreate is called when a new discord.AuditLogEntry is created
 type GuildAuditLogEntryCreate struct {
-	*GenericEvent
-	GuildID       snowflake.ID
+	*GenericGuild
 	AuditLogEntry discord.AuditLogEntry
 }

--- a/handlers/guild_ban_handlers.go
+++ b/handlers/guild_ban_handlers.go
@@ -7,17 +7,25 @@ import (
 )
 
 func gatewayHandlerGuildBanAdd(client bot.Client, sequenceNumber int, shardID int, event gateway.EventGuildBanAdd) {
-	client.EventManager().DispatchEvent(&events.GuildBan{
+	genericGuildEvent := &events.GenericGuild{
 		GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
 		GuildID:      event.GuildID,
+	}
+
+	client.EventManager().DispatchEvent(&events.GuildBan{
+		GenericGuild: genericGuildEvent,
 		User:         event.User,
 	})
 }
 
 func gatewayHandlerGuildBanRemove(client bot.Client, sequenceNumber int, shardID int, event gateway.EventGuildBanRemove) {
-	client.EventManager().DispatchEvent(&events.GuildUnban{
+	genericGuildEvent := &events.GenericGuild{
 		GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
 		GuildID:      event.GuildID,
+	}
+
+	client.EventManager().DispatchEvent(&events.GuildUnban{
+		GenericGuild: genericGuildEvent,
 		User:         event.User,
 	})
 }

--- a/handlers/guild_handlers.go
+++ b/handlers/guild_handlers.go
@@ -70,13 +70,13 @@ func gatewayHandlerGuildCreate(client bot.Client, sequenceNumber int, shardID in
 	genericGuildEvent := &events.GenericGuild{
 		GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
 		GuildID:      event.ID,
-		Guild:        event.Guild,
 	}
 
 	if wasUnready {
 		client.Caches().SetGuildUnready(event.ID, false)
 		client.EventManager().DispatchEvent(&events.GuildReady{
 			GenericGuild: genericGuildEvent,
+			Guild:        event.GatewayGuild,
 		})
 		if len(client.Caches().UnreadyGuildIDs()) == 0 {
 			client.EventManager().DispatchEvent(&events.GuildsReady{
@@ -97,10 +97,12 @@ func gatewayHandlerGuildCreate(client bot.Client, sequenceNumber int, shardID in
 		client.Caches().SetGuildUnavailable(event.ID, false)
 		client.EventManager().DispatchEvent(&events.GuildAvailable{
 			GenericGuild: genericGuildEvent,
+			Guild:        event.GatewayGuild,
 		})
 	} else {
 		client.EventManager().DispatchEvent(&events.GuildJoin{
 			GenericGuild: genericGuildEvent,
+			Guild:        event.GatewayGuild,
 		})
 	}
 }
@@ -112,8 +114,9 @@ func gatewayHandlerGuildUpdate(client bot.Client, sequenceNumber int, shardID in
 	client.EventManager().DispatchEvent(&events.GuildUpdate{
 		GenericGuild: &events.GenericGuild{
 			GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
-			Guild:        event.Guild,
+			GuildID:      event.ID,
 		},
+		Guild:    event.Guild,
 		OldGuild: oldGuild,
 	})
 }
@@ -145,24 +148,29 @@ func gatewayHandlerGuildDelete(client bot.Client, sequenceNumber int, shardID in
 	genericGuildEvent := &events.GenericGuild{
 		GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
 		GuildID:      event.ID,
-		Guild:        guild,
 	}
 
 	if event.Unavailable {
 		client.EventManager().DispatchEvent(&events.GuildUnavailable{
 			GenericGuild: genericGuildEvent,
+			Guild:        guild,
 		})
 	} else {
 		client.EventManager().DispatchEvent(&events.GuildLeave{
 			GenericGuild: genericGuildEvent,
+			Guild:        guild,
 		})
 	}
 }
 
 func gatewayHandlerGuildAuditLogEntryCreate(client bot.Client, sequenceNumber int, shardID int, event gateway.EventGuildAuditLogEntryCreate) {
+	genericGuildEvent := &events.GenericGuild{
+		GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
+		GuildID:      event.GuildID,
+	}
+
 	client.EventManager().DispatchEvent(&events.GuildAuditLogEntryCreate{
-		GenericEvent:  events.NewGenericEvent(client, sequenceNumber, shardID),
-		GuildID:       event.GuildID,
+		GenericGuild:  genericGuildEvent,
 		AuditLogEntry: event.AuditLogEntry,
 	})
 }


### PR DESCRIPTION
Currently only the partial `Guild` object is passed, which is missing some [extra fields](https://discord.com/developers/docs/events/gateway-events#guild-create-guild-create-extra-fields).