### PR TITLE
Fix race condition with async events enabled in DispatchEvent

### DIFF
--- a/bot/event_manager.go
+++ b/bot/event_manager.go
@@ -154,10 +154,9 @@ func (e *eventManagerImpl) DispatchEvent(event Event) {
 	}()
 	e.eventListenerMu.Lock()
 	defer e.eventListenerMu.Unlock()
-	for _, l := range e.eventListeners {
-		listener := l
+	for _, listener := range e.eventListeners {
 		if e.asyncEventsEnabled {
-			go func() {
+			go func(listener EventListener) {
 				defer func() {
 					if r := recover(); r != nil {
 						e.logger.Error("recovered from panic in event listener", slog.Any("arg", r), slog.String("stack", string(debug.Stack())))
@@ -165,7 +164,7 @@ func (e *eventManagerImpl) DispatchEvent(event Event) {
 					}
 				}()
 				listener.OnEvent(event)
-			}()
+			}(listener)
 			continue
 		}
 		listener.OnEvent(event)

--- a/bot/event_manager.go
+++ b/bot/event_manager.go
@@ -154,20 +154,21 @@ func (e *eventManagerImpl) DispatchEvent(event Event) {
 	}()
 	e.eventListenerMu.Lock()
 	defer e.eventListenerMu.Unlock()
-	for i := range e.eventListeners {
+	for _, l := range e.eventListeners {
+		listener := l
 		if e.asyncEventsEnabled {
-			go func(i int) {
+			go func() {
 				defer func() {
 					if r := recover(); r != nil {
 						e.logger.Error("recovered from panic in event listener", slog.Any("arg", r), slog.String("stack", string(debug.Stack())))
 						return
 					}
 				}()
-				e.eventListeners[i].OnEvent(event)
-			}(i)
+				listener.OnEvent(event)
+			}()
 			continue
 		}
-		e.eventListeners[i].OnEvent(event)
+		listener.OnEvent(event)
 	}
 }
 


### PR DESCRIPTION
The goroutine could execute after eventListenersMu unlocked, which could cause out-of-bounds access to the slice and race conditions.