### PR TITLE
rest: Lock mutex in rateLimiterImpl.Close

### DIFF
--- a/rest/rest_rate_limiter.go
+++ b/rest/rest_rate_limiter.go
@@ -184,6 +184,7 @@ func (l *rateLimiterImpl) WaitBucket(ctx context.Context, endpoint *CompiledEndp
 	if until.After(now) {
 		// TODO: do we want to return early when we know the rate limit bigger than ctx deadline?
 		if deadline, ok := ctx.Deadline(); ok && until.After(deadline) {
+			b.mu.Unlock()
 			return context.DeadlineExceeded
 		}
 

--- a/rest/rest_rate_limiter.go
+++ b/rest/rest_rate_limiter.go
@@ -115,15 +115,14 @@ func (l *rateLimiterImpl) Close(ctx context.Context) {
 }
 
 func (l *rateLimiterImpl) Reset() {
-	l.global = time.Time{}
-
 	l.bucketsMu.Lock()
-	clear(l.buckets)
-	l.bucketsMu.Unlock()
-
 	l.hashesMu.Lock()
+	defer l.bucketsMu.Unlock()
+	defer l.hashesMu.Unlock()
+
+	l.global = time.Time{}
+	clear(l.buckets)
 	clear(l.hashes)
-	l.hashesMu.Unlock()
 }
 
 func (l *rateLimiterImpl) getRouteHash(endpoint *CompiledEndpoint) string {


### PR DESCRIPTION
Silences a complaint from the race detector. Also refactored Reset to not overwrite mutexes and use `clear` to delete all map entries (more idiomatic, I guess).