### PR TITLE
fix: access named variables in middlewares

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -72,7 +72,7 @@ func (h *handlerHolder[T]) Match(path string, t discord.InteractionType, t2 int)
 	return true
 }
 
-func (h *handlerHolder[T]) Handle(path string, event *InteractionEvent) error {
+func (h *handlerHolder[T]) Handle(path string, event *InteractionEvent, routerMiddlewares ...Middleware) error {
 	parseVariables(path, h.pattern, event.Vars)
 
 	handlerChain := Handler(func(event *InteractionEvent) error {
@@ -189,8 +189,11 @@ func (h *handlerHolder[T]) Handle(path string, event *InteractionEvent) error {
 		return errors.New("unknown handler type")
 	})
 
-	for i := len(h.middlewares) - 1; i >= 0; i-- {
-		handlerChain = h.middlewares[i](handlerChain)
+	middlewares := routerMiddlewares
+	middlewares = append(middlewares, h.middlewares...)
+
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handlerChain = middlewares[i](handlerChain)
 	}
 
 	return handlerChain(event)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -46,11 +46,10 @@ func SyncCommands(client bot.Client, commands []discord.ApplicationCommandCreate
 }
 
 type handlerHolder[T any] struct {
-	pattern     string
-	middlewares []Middleware
-	handler     T
-	t           discord.InteractionType
-	t2          []int
+	pattern string
+	handler T
+	t       discord.InteractionType
+	t2      []int
 }
 
 func (h *handlerHolder[T]) Match(path string, t discord.InteractionType, t2 int) bool {
@@ -189,17 +188,9 @@ func (h *handlerHolder[T]) Handle(path string, event *InteractionEvent, routerMi
 		return errors.New("unknown handler type")
 	})
 
-	middlewares := routerMiddlewares
-	middlewares = append(middlewares, h.middlewares...)
-
-	for i := len(middlewares) - 1; i >= 0; i-- {
-		handlerChain = middlewares[i](handlerChain)
+	for i := len(routerMiddlewares) - 1; i >= 0; i-- {
+		handlerChain = routerMiddlewares[i](handlerChain)
 	}
 
 	return handlerChain(event)
-}
-
-// Use adds the given middlewares to the current Route.
-func (h *handlerHolder[T]) Use(middlewares ...Middleware) {
-	h.middlewares = append(h.middlewares, middlewares...)
 }

--- a/handler/mux.go
+++ b/handler/mux.go
@@ -173,117 +173,107 @@ func (r *Mux) handle(route Route) {
 
 // Interaction registers the given InteractionHandler to the current Router.
 // This is a shortcut for Command, Autocomplete, Component and Modal.
-func (r *Mux) Interaction(pattern string, h InteractionHandler, middlewares ...Middleware) {
+func (r *Mux) Interaction(pattern string, h InteractionHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[InteractionHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionType(0),
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionType(0),
 	})
 }
 
 // Command registers the given CommandHandler to the current Router.
-func (r *Mux) Command(pattern string, h CommandHandler, middlewares ...Middleware) {
+func (r *Mux) Command(pattern string, h CommandHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[CommandHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeApplicationCommand,
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeApplicationCommand,
 	})
 }
 
 // SlashCommand registers the given SlashCommandHandler to the current Router.
-func (r *Mux) SlashCommand(pattern string, h SlashCommandHandler, middlewares ...Middleware) {
+func (r *Mux) SlashCommand(pattern string, h SlashCommandHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[SlashCommandHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeApplicationCommand,
-		t2:          []int{int(discord.ApplicationCommandTypeSlash)},
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeApplicationCommand,
+		t2:      []int{int(discord.ApplicationCommandTypeSlash)},
 	})
 }
 
 // UserCommand registers the given UserCommandHandler to the current Router.
-func (r *Mux) UserCommand(pattern string, h UserCommandHandler, middlewares ...Middleware) {
+func (r *Mux) UserCommand(pattern string, h UserCommandHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[UserCommandHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeApplicationCommand,
-		t2:          []int{int(discord.ApplicationCommandTypeUser)},
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeApplicationCommand,
+		t2:      []int{int(discord.ApplicationCommandTypeUser)},
 	})
 }
 
 // MessageCommand registers the given MessageCommandHandler to the current Router.
-func (r *Mux) MessageCommand(pattern string, h MessageCommandHandler, middlewares ...Middleware) {
+func (r *Mux) MessageCommand(pattern string, h MessageCommandHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[MessageCommandHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeApplicationCommand,
-		t2:          []int{int(discord.ApplicationCommandTypeMessage)},
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeApplicationCommand,
+		t2:      []int{int(discord.ApplicationCommandTypeMessage)},
 	})
 }
 
 // EntryPointCommand registers the given EntryPointCommandHandler to the current Router.
-func (r *Mux) EntryPointCommand(pattern string, h EntryPointCommandHandler, middlewares ...Middleware) {
+func (r *Mux) EntryPointCommand(pattern string, h EntryPointCommandHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[EntryPointCommandHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeApplicationCommand,
-		t2:          []int{int(discord.ApplicationCommandTypePrimaryEntryPoint)},
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeApplicationCommand,
+		t2:      []int{int(discord.ApplicationCommandTypePrimaryEntryPoint)},
 	})
 }
 
 // Autocomplete registers the given AutocompleteHandler to the current Router.
-func (r *Mux) Autocomplete(pattern string, h AutocompleteHandler, middlewares ...Middleware) {
+func (r *Mux) Autocomplete(pattern string, h AutocompleteHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[AutocompleteHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeAutocomplete,
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeAutocomplete,
 	})
 }
 
 // Component registers the given ComponentHandler to the current Router.
-func (r *Mux) Component(pattern string, h ComponentHandler, middlewares ...Middleware) {
+func (r *Mux) Component(pattern string, h ComponentHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[ComponentHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeComponent,
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeComponent,
 	})
 }
 
 // ButtonComponent registers the given ButtonComponentHandler to the current Router.
-func (r *Mux) ButtonComponent(pattern string, h ButtonComponentHandler, middlewares ...Middleware) {
+func (r *Mux) ButtonComponent(pattern string, h ButtonComponentHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[ButtonComponentHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeComponent,
-		t2:          []int{int(discord.ComponentTypeButton)},
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeComponent,
+		t2:      []int{int(discord.ComponentTypeButton)},
 	})
 }
 
 // SelectMenuComponent registers the given SelectMenuComponentHandler to the current Router.
-func (r *Mux) SelectMenuComponent(pattern string, h SelectMenuComponentHandler, middlewares ...Middleware) {
+func (r *Mux) SelectMenuComponent(pattern string, h SelectMenuComponentHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[SelectMenuComponentHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeComponent,
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeComponent,
 		t2: []int{
 			int(discord.ComponentTypeStringSelectMenu),
 			int(discord.ComponentTypeUserSelectMenu),
@@ -295,13 +285,12 @@ func (r *Mux) SelectMenuComponent(pattern string, h SelectMenuComponentHandler, 
 }
 
 // Modal registers the given ModalHandler to the current Router.
-func (r *Mux) Modal(pattern string, h ModalHandler, middlewares ...Middleware) {
+func (r *Mux) Modal(pattern string, h ModalHandler) {
 	checkPattern(pattern)
 	r.handle(&handlerHolder[ModalHandler]{
-		pattern:     pattern,
-		middlewares: middlewares,
-		handler:     h,
-		t:           discord.InteractionTypeModalSubmit,
+		pattern: pattern,
+		handler: h,
+		t:       discord.InteractionTypeModalSubmit,
 	})
 }
 

--- a/handler/mux.go
+++ b/handler/mux.go
@@ -107,7 +107,7 @@ func (r *Mux) Match(path string, t discord.InteractionType, t2 int) bool {
 }
 
 // Handle handles the given interaction event.
-func (r *Mux) Handle(path string, event *InteractionEvent) error {
+func (r *Mux) Handle(path string, event *InteractionEvent, _ ...Middleware) error {
 	path = parseVariables(path, r.pattern, event.Vars)
 
 	t := event.Type()
@@ -121,8 +121,7 @@ func (r *Mux) Handle(path string, event *InteractionEvent) error {
 
 	for _, route := range r.routes {
 		if route.Match(path, t, t2) {
-			route.Use(r.middlewares...)
-			return route.Handle(path, event)
+			return route.Handle(path, event, r.middlewares...)
 		}
 	}
 

--- a/handler/router.go
+++ b/handler/router.go
@@ -36,9 +36,6 @@ type Route interface {
 
 	// Handle handles the given interaction event.
 	Handle(path string, e *InteractionEvent, middlewares ...Middleware) error
-
-	// Use adds the given middlewares to the current Route.
-	Use(middlewares ...Middleware)
 }
 
 // Router provides with the core routing functionality.
@@ -46,6 +43,9 @@ type Route interface {
 type Router interface {
 	bot.EventListener
 	Route
+
+	// Use adds the given middlewares to the current Router.
+	Use(middlewares ...Middleware)
 
 	// With returns a new Router with the given middlewares.
 	With(middlewares ...Middleware) Router
@@ -60,35 +60,35 @@ type Router interface {
 	Mount(pattern string, r Router)
 
 	// Interaction registers the given InteractionHandler to the current Router.
-	Interaction(pattern string, h InteractionHandler, middlewares ...Middleware)
+	Interaction(pattern string, h InteractionHandler)
 
 	// Command registers the given CommandHandler to the current Router.
-	Command(pattern string, h CommandHandler, middlewares ...Middleware)
+	Command(pattern string, h CommandHandler)
 
 	// SlashCommand registers the given SlashCommandHandler to the current Router.
-	SlashCommand(pattern string, h SlashCommandHandler, middlewares ...Middleware)
+	SlashCommand(pattern string, h SlashCommandHandler)
 
 	// UserCommand registers the given UserCommandHandler to the current Router.
-	UserCommand(pattern string, h UserCommandHandler, middlewares ...Middleware)
+	UserCommand(pattern string, h UserCommandHandler)
 
 	// MessageCommand registers the given MessageCommandHandler to the current Router.
-	MessageCommand(pattern string, h MessageCommandHandler, middlewares ...Middleware)
+	MessageCommand(pattern string, h MessageCommandHandler)
 
 	// EntryPointCommand registers the given EntryPointCommandHandler to the current Router.
-	EntryPointCommand(pattern string, h EntryPointCommandHandler, middlewares ...Middleware)
+	EntryPointCommand(pattern string, h EntryPointCommandHandler)
 
 	// Autocomplete registers the given AutocompleteHandler to the current Router.
-	Autocomplete(pattern string, h AutocompleteHandler, middlewares ...Middleware)
+	Autocomplete(pattern string, h AutocompleteHandler)
 
 	// Component registers the given ComponentHandler to the current Router.
-	Component(pattern string, h ComponentHandler, middlewares ...Middleware)
+	Component(pattern string, h ComponentHandler)
 
 	// ButtonComponent registers the given ButtonComponentHandler to the current Router.
-	ButtonComponent(pattern string, h ButtonComponentHandler, middlewares ...Middleware)
+	ButtonComponent(pattern string, h ButtonComponentHandler)
 
 	// SelectMenuComponent registers the given SelectMenuComponentHandler to the current Router.
-	SelectMenuComponent(pattern string, h SelectMenuComponentHandler, middlewares ...Middleware)
+	SelectMenuComponent(pattern string, h SelectMenuComponentHandler)
 
 	// Modal registers the given ModalHandler to the current Router.
-	Modal(pattern string, h ModalHandler, middlewares ...Middleware)
+	Modal(pattern string, h ModalHandler)
 }

--- a/handler/router.go
+++ b/handler/router.go
@@ -35,7 +35,7 @@ type Route interface {
 	Match(path string, t discord.InteractionType, t2 int) bool
 
 	// Handle handles the given interaction event.
-	Handle(path string, e *InteractionEvent) error
+	Handle(path string, e *InteractionEvent, middlewares ...Middleware) error
 
 	// Use adds the given middlewares to the current Route.
 	Use(middlewares ...Middleware)

--- a/handler/router.go
+++ b/handler/router.go
@@ -36,6 +36,9 @@ type Route interface {
 
 	// Handle handles the given interaction event.
 	Handle(path string, e *InteractionEvent) error
+
+	// Use adds the given middlewares to the current Route.
+	Use(middlewares ...Middleware)
 }
 
 // Router provides with the core routing functionality.
@@ -43,9 +46,6 @@ type Route interface {
 type Router interface {
 	bot.EventListener
 	Route
-
-	// Use adds the given middlewares to the current Router.
-	Use(middlewares ...Middleware)
 
 	// With returns a new Router with the given middlewares.
 	With(middlewares ...Middleware) Router
@@ -60,35 +60,35 @@ type Router interface {
 	Mount(pattern string, r Router)
 
 	// Interaction registers the given InteractionHandler to the current Router.
-	Interaction(pattern string, h InteractionHandler)
+	Interaction(pattern string, h InteractionHandler, middlewares ...Middleware)
 
 	// Command registers the given CommandHandler to the current Router.
-	Command(pattern string, h CommandHandler)
+	Command(pattern string, h CommandHandler, middlewares ...Middleware)
 
 	// SlashCommand registers the given SlashCommandHandler to the current Router.
-	SlashCommand(pattern string, h SlashCommandHandler)
+	SlashCommand(pattern string, h SlashCommandHandler, middlewares ...Middleware)
 
 	// UserCommand registers the given UserCommandHandler to the current Router.
-	UserCommand(pattern string, h UserCommandHandler)
+	UserCommand(pattern string, h UserCommandHandler, middlewares ...Middleware)
 
 	// MessageCommand registers the given MessageCommandHandler to the current Router.
-	MessageCommand(pattern string, h MessageCommandHandler)
+	MessageCommand(pattern string, h MessageCommandHandler, middlewares ...Middleware)
 
 	// EntryPointCommand registers the given EntryPointCommandHandler to the current Router.
-	EntryPointCommand(pattern string, h EntryPointCommandHandler)
+	EntryPointCommand(pattern string, h EntryPointCommandHandler, middlewares ...Middleware)
 
 	// Autocomplete registers the given AutocompleteHandler to the current Router.
-	Autocomplete(pattern string, h AutocompleteHandler)
+	Autocomplete(pattern string, h AutocompleteHandler, middlewares ...Middleware)
 
 	// Component registers the given ComponentHandler to the current Router.
-	Component(pattern string, h ComponentHandler)
+	Component(pattern string, h ComponentHandler, middlewares ...Middleware)
 
 	// ButtonComponent registers the given ButtonComponentHandler to the current Router.
-	ButtonComponent(pattern string, h ButtonComponentHandler)
+	ButtonComponent(pattern string, h ButtonComponentHandler, middlewares ...Middleware)
 
 	// SelectMenuComponent registers the given SelectMenuComponentHandler to the current Router.
-	SelectMenuComponent(pattern string, h SelectMenuComponentHandler)
+	SelectMenuComponent(pattern string, h SelectMenuComponentHandler, middlewares ...Middleware)
 
 	// Modal registers the given ModalHandler to the current Router.
-	Modal(pattern string, h ModalHandler)
+	Modal(pattern string, h ModalHandler, middlewares ...Middleware)
 }


### PR DESCRIPTION
I moved the execution of middlewares to the Handle of the matched route, and not before finding the routes, since otherwise it is impossible to access the pattern of the route, and accordingly to get named variables in this route. This allows access to e.Vars inside the middleware, as well as the ability to add middlewares for each specific route