### PR TITLE
fix: populate GuildID to Member in interactions

### DIFF
--- a/discord/interaction_application_command.go
+++ b/discord/interaction_application_command.go
@@ -87,6 +87,10 @@ func (i *ApplicationCommandInteraction) UnmarshalJSON(data []byte) error {
 	i.baseInteraction.authorizingIntegrationOwners = interaction.AuthorizingIntegrationOwners
 	i.baseInteraction.context = interaction.Context
 
+	if i.baseInteraction.member != nil && i.baseInteraction.guildID != nil {
+		i.baseInteraction.member.GuildID = *i.baseInteraction.guildID
+	}
+
 	i.Data = interactionData
 	return nil
 }

--- a/discord/interaction_autocomplete.go
+++ b/discord/interaction_autocomplete.go
@@ -40,6 +40,10 @@ func (i *AutocompleteInteraction) UnmarshalJSON(data []byte) error {
 	i.baseInteraction.authorizingIntegrationOwners = interaction.AuthorizingIntegrationOwners
 	i.baseInteraction.context = interaction.Context
 
+	if i.baseInteraction.member != nil && i.baseInteraction.guildID != nil {
+		i.baseInteraction.member.GuildID = *i.baseInteraction.guildID
+	}
+
 	i.Data = interaction.Data
 	return nil
 }

--- a/discord/interaction_component.go
+++ b/discord/interaction_component.go
@@ -93,6 +93,10 @@ func (i *ComponentInteraction) UnmarshalJSON(data []byte) error {
 	i.baseInteraction.authorizingIntegrationOwners = interaction.AuthorizingIntegrationOwners
 	i.baseInteraction.context = interaction.Context
 
+	if i.baseInteraction.member != nil && i.baseInteraction.guildID != nil {
+		i.baseInteraction.member.GuildID = *i.baseInteraction.guildID
+	}
+
 	i.Data = interactionData
 	i.Message = interaction.Message
 	i.Message.GuildID = i.baseInteraction.guildID

--- a/discord/interaction_modal_submit.go
+++ b/discord/interaction_modal_submit.go
@@ -37,6 +37,10 @@ func (i *ModalSubmitInteraction) UnmarshalJSON(data []byte) error {
 	i.baseInteraction.authorizingIntegrationOwners = interaction.AuthorizingIntegrationOwners
 	i.baseInteraction.context = interaction.Context
 
+	if i.baseInteraction.member != nil && i.baseInteraction.guildID != nil {
+		i.baseInteraction.member.GuildID = *i.baseInteraction.guildID
+	}
+
 	i.Data = interaction.Data
 	return nil
 }


### PR DESCRIPTION
Currently GuildID field in Member in interactions is equal 0, so cache functions doesn't work for this field, like MemberPermissions