### PR TITLE
rest_client: propagate context to the http.Request

### DIFF
--- a/discord/webhook.go
+++ b/discord/webhook.go
@@ -333,7 +333,7 @@ func (ApplicationWebhook) webhook() {}
 type WebhookSourceGuild struct {
 	ID   snowflake.ID         `json:"id"`
 	Name string               `json:"name"`
-	Icon *json.Nullable[Icon] `json:"icon"`
+	Icon *string              `json:"icon"`
 }
 
 type WebhookSourceChannel struct {

--- a/rest/rest_client.go
+++ b/rest/rest_client.go
@@ -121,7 +121,7 @@ func (c *clientImpl) retry(endpoint *CompiledEndpoint, rqBody any, rsBody any, t
 	if err != nil {
 		return fmt.Errorf("error locking bucket in rest client: %w", err)
 	}
-	rq = rq.WithContext(config.Ctx)
+	config.Request = config.Request.WithContext(config.Ctx)
 
 	for _, check := range config.Checks {
 		if !check() {
@@ -160,12 +160,12 @@ func (c *clientImpl) retry(endpoint *CompiledEndpoint, rqBody any, rsBody any, t
 
 	case http.StatusTooManyRequests:
 		if tries >= c.RateLimiter().MaxRetries() {
-			return NewError(rq, rawRqBody, rs, rawRsBody)
+			return NewError(config.Request, rawRqBody, rs, rawRsBody)
 		}
 		return c.retry(endpoint, rqBody, rsBody, tries+1, opts)
 
 	default:
-		return NewError(rq, rawRqBody, rs, rawRsBody)
+		return NewError(config.Request, rawRqBody, rs, rawRsBody)
 	}
 }
 


### PR DESCRIPTION
Currently, the context is added to `rq`, but it is not used for the real HTTP call - the `config.Request` is used instead.

This fixes that behaviour, adding the context to the `config.Request` instead.