### PR TITLE
Fix `Members.UpdateCurrentMember` to return `discord.Member`

### DIFF
--- a/rest/members.go
+++ b/rest/members.go
@@ -23,7 +23,7 @@ type Members interface {
 	AddMemberRole(guildID snowflake.ID, userID snowflake.ID, roleID snowflake.ID, opts ...RequestOpt) error
 	RemoveMemberRole(guildID snowflake.ID, userID snowflake.ID, roleID snowflake.ID, opts ...RequestOpt) error
 
-	UpdateCurrentMember(guildID snowflake.ID, nick string, opts ...RequestOpt) (*string, error)
+	UpdateCurrentMember(guildID snowflake.ID, nick string, opts ...RequestOpt) (*discord.Member, error)
 
 	GetCurrentUserVoiceState(guildID snowflake.ID, opts ...RequestOpt) (*discord.VoiceState, error)
 	GetUserVoiceState(guildID snowflake.ID, userID snowflake.ID, opts ...RequestOpt) (*discord.VoiceState, error)
@@ -102,8 +102,8 @@ func (s *memberImpl) RemoveMemberRole(guildID snowflake.ID, userID snowflake.ID,
 	return s.client.Do(RemoveMemberRole.Compile(nil, guildID, userID, roleID), nil, nil, opts...)
 }
 
-func (s *memberImpl) UpdateCurrentMember(guildID snowflake.ID, nick string, opts ...RequestOpt) (nickName *string, err error) {
-	err = s.client.Do(UpdateCurrentMember.Compile(nil, guildID), discord.CurrentMemberUpdate{Nick: nick}, nickName, opts...)
+func (s *memberImpl) UpdateCurrentMember(guildID snowflake.ID, nick string, opts ...RequestOpt) (member *discord.Member, err error) {
+	err = s.client.Do(UpdateCurrentMember.Compile(nil, guildID), discord.CurrentMemberUpdate{Nick: nick}, &member, opts...)
 	return
 }
 


### PR DESCRIPTION
According to the [Discord OpenAPI spec](https://github.com/discord/discord-api-spec/blame/c020f56f103767169d22e12d60f57c810ab98a8a/specs/openapi.json#L5121), the `/guilds/{guild_id}/members/@me` endpoint, used by `Members.UpdateCurrentMember`, returns the same response structure as `/users/@me/guilds/{guild_id}/member`, which is used by `OAuth2.GetCurrentMember` and returns a `discord.Member`.

This fixes the following error caused by attempting to unmarshal into an incorrect response type:
```
error unmarshalling response body name=rest_client err="json: Unmarshal(nil string)" endpoint=/guilds/***********/members/@me code="200 OK" body="{"avatar":null,"...
```