### PR TITLE
fix: multiple gateway logic bugfixes

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -378,7 +378,6 @@ func (g *gatewayImpl) Presence() *MessageDataPresenceUpdate {
 	return g.config.Presence
 }
 
-// FIXME: Removed the recursiveness here
 func (g *gatewayImpl) doReconnect(ctx context.Context) error {
 	try := 0
 
@@ -427,7 +426,6 @@ func (g *gatewayImpl) reconnect() {
 	if err := g.doReconnect(context.Background()); err != nil {
 		g.config.Logger.Error("failed to reopen gateway", slog.Any("err", err))
 
-		// FIXME: Fix 2
 		if g.closeHandlerFunc != nil {
 			g.closeHandlerFunc(g, err, false)
 		}
@@ -630,13 +628,13 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 			if readyEvent, ok := eventData.(EventReady); ok {
 				g.config.SessionID = &readyEvent.SessionID
 				g.config.ResumeURL = &readyEvent.ResumeGatewayURL
-				g.config.Logger.Debug("ready message received")
+				g.config.Logger.Info("succesfully started", slog.String("sessionID", *g.config.SessionID))
 				g.statusMu.Lock()
 				g.status = StatusReady
 				g.statusMu.Unlock()
 				ready(nil)
 			} else if _, ok = eventData.(EventResumed); ok {
-				g.config.Logger.Debug("resume message received")
+				g.config.Logger.Info("successfully resumed", slog.String("sessionID", *g.config.SessionID))
 				g.statusMu.Lock()
 				g.status = StatusReady
 				g.statusMu.Unlock()

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -661,6 +661,8 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 			g.sendHeartbeat()
 
 		case OpcodeReconnect:
+			g.config.Logger.Info("received instruction to reconnect")
+
 			// We might receive a reconnect as the first opcode (even before HELLO)
 			g.statusMu.Lock()
 			if g.status != StatusReady {
@@ -688,6 +690,8 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 				g.config.LastSequenceReceived = nil
 				g.config.ResumeURL = nil
 			}
+
+			g.config.Logger.Warn("received invalid session", slog.Bool("canResume", bool(canResume)))
 
 			g.statusMu.Lock()
 			if g.status != StatusReady {


### PR DESCRIPTION
- Properly scope `sync.Once` to avoid deadlocks 
- Add `defer ready(nil)` to `listen` to ensure it never leaves without setting the channel (avoid deadlocks)
- Pass an error to `ready` on invalid session and reconnect (if shard is not ready) to avoid `open` from thinking the shard has successfully started when it hasn't
	- This also helps the sharder not believe the shards are up
- Replace `reconnectTry` with `doReconnect`, which is the same logic but it removes the recursiveness
- Fix potential null pointer dereference in reconnect,
- Set ready channel as an unbuffered channel
- Improve INFO logging for invalid sessions/reconnects
- Properly handle RECONNECT as the first opcode