### PR TITLE
Fix logical condition in ShardByGuildID method

### DIFF
--- a/sharding/shard_manager.go
+++ b/sharding/shard_manager.go
@@ -237,7 +237,7 @@ func (m *shardManagerImpl) CloseShard(ctx context.Context, shardID int) {
 func (m *shardManagerImpl) ShardByGuildID(guildId snowflake.ID) gateway.Gateway {
 	shardCount := m.config.ShardCount
 	var shard gateway.Gateway
-	for shard == nil || shardCount != 0 {
+	for shard == nil && shardCount != 0 {
 		shard = m.Shard(ShardIDByGuild(guildId, shardCount))
 		shardCount /= m.config.ShardSplitCount
 	}


### PR DESCRIPTION
Currently this leads to a panic because we divide by 0 in ShardIDByGuild, so we should always check if shardCount is not 0