### PR TITLE
Fix 4006 reconnect

### DIFF
--- a/voice/conn.go
+++ b/voice/conn.go
@@ -95,8 +95,10 @@ type connImpl struct {
 	gateway Gateway
 	udp     UDPConn
 
-	audioSender   AudioSender
-	audioReceiver AudioReceiver
+	audioSender       AudioSender
+	audioReceiver     AudioReceiver
+	opusFrameProvider OpusFrameProvider
+	opusFrameReceiver OpusFrameReceiver
 
 	openedChan chan struct{}
 	closedChan chan struct{}
@@ -151,6 +153,7 @@ func (c *connImpl) UDP() UDPConn {
 }
 
 func (c *connImpl) SetOpusFrameProvider(provider OpusFrameProvider) {
+	c.opusFrameProvider = provider
 	if c.audioSender != nil {
 		c.audioSender.Close()
 	}
@@ -159,6 +162,7 @@ func (c *connImpl) SetOpusFrameProvider(provider OpusFrameProvider) {
 }
 
 func (c *connImpl) SetOpusFrameReceiver(handler OpusFrameReceiver) {
+	c.opusFrameReceiver = handler
 	if c.audioReceiver != nil {
 		c.audioReceiver.Close()
 	}
@@ -244,6 +248,26 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 		if err := c.udp.SetSecretKey(d.Mode, d.SecretKey); err != nil {
 			c.config.Logger.Error("voice: failed to set secret key", slog.Any("err", err))
 		}
+
+		// Restart audio sender/receiver if they were previously configured.
+		// This handles the case where a reconnect resulted in a new session
+		// (Identify instead of Resume), which replaces the UDP connection and
+		// causes the old sender/receiver goroutines to exit.
+		if c.opusFrameProvider != nil {
+			if c.audioSender != nil {
+				c.audioSender.Close()
+			}
+			c.audioSender = c.config.AudioSenderCreateFunc(c.config.Logger, c.opusFrameProvider, c)
+			c.audioSender.Open()
+		}
+		if c.opusFrameReceiver != nil {
+			if c.audioReceiver != nil {
+				c.audioReceiver.Close()
+			}
+			c.audioReceiver = c.config.AudioReceiverCreateFunc(c.config.Logger, c.opusFrameReceiver, c)
+			c.audioReceiver.Open()
+		}
+
 		c.openedChan <- struct{}{}
 
 	case GatewayMessageDataSpeaking:

--- a/voice/conn_test.go
+++ b/voice/conn_test.go
@@ -1,0 +1,179 @@
+package voice
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// fakeAudioSender is a minimal AudioSender for testing.
+type fakeAudioSender struct {
+	closed atomic.Bool
+}
+
+func (f *fakeAudioSender) Open()  {}
+func (f *fakeAudioSender) Close() { f.closed.Store(true) }
+
+// fakeAudioReceiver is a minimal AudioReceiver for testing.
+type fakeAudioReceiver struct {
+	closed atomic.Bool
+}
+
+func (f *fakeAudioReceiver) Open()                      {}
+func (f *fakeAudioReceiver) CleanupUser(_ snowflake.ID) {}
+func (f *fakeAudioReceiver) Close()                     { f.closed.Store(true) }
+
+// fakeOpusFrameProvider is a minimal OpusFrameProvider for testing.
+type fakeOpusFrameProvider struct{}
+
+func (f *fakeOpusFrameProvider) ProvideOpusFrame() ([]byte, error) { return nil, nil }
+func (f *fakeOpusFrameProvider) Close()                            {}
+
+// fakeOpusFrameReceiver is a minimal OpusFrameReceiver for testing.
+type fakeOpusFrameReceiver struct{}
+
+func (f *fakeOpusFrameReceiver) ReceiveOpusFrame(_ snowflake.ID, _ *Packet) error { return nil }
+func (f *fakeOpusFrameReceiver) CleanupUser(_ snowflake.ID)                       {}
+func (f *fakeOpusFrameReceiver) Close()                                           {}
+
+// fakeUDPConn is a minimal UDPConn stub that satisfies the interface for testing.
+type fakeUDPConn struct{}
+
+func (f *fakeUDPConn) LocalAddr() net.Addr                           { return nil }
+func (f *fakeUDPConn) RemoteAddr() net.Addr                          { return nil }
+func (f *fakeUDPConn) SetSecretKey(_ EncryptionMode, _ []byte) error { return nil }
+func (f *fakeUDPConn) SetDeadline(_ time.Time) error                 { return nil }
+func (f *fakeUDPConn) SetReadDeadline(_ time.Time) error             { return nil }
+func (f *fakeUDPConn) SetWriteDeadline(_ time.Time) error            { return nil }
+func (f *fakeUDPConn) Open(_ context.Context, _ string, _ int, _ uint32) (string, int, error) {
+	return "127.0.0.1", 0, nil
+}
+func (f *fakeUDPConn) Close() error                 { return nil }
+func (f *fakeUDPConn) Read(_ []byte) (int, error)   { return 0, nil }
+func (f *fakeUDPConn) ReadPacket() (*Packet, error) { return nil, nil }
+func (f *fakeUDPConn) Write(_ []byte) (int, error)  { return 0, nil }
+
+func TestHandleMessage_SessionDescription_RestartsAudioPipeline(t *testing.T) {
+	var (
+		senderCreateCount   atomic.Int32
+		receiverCreateCount atomic.Int32
+	)
+
+	// Track each sender/receiver instance created.
+	var lastSender *fakeAudioSender
+	var lastReceiver *fakeAudioReceiver
+
+	senderCreateFunc := func(logger *slog.Logger, provider OpusFrameProvider, conn Conn) AudioSender {
+		senderCreateCount.Add(1)
+		s := &fakeAudioSender{}
+		lastSender = s
+		return s
+	}
+
+	receiverCreateFunc := func(logger *slog.Logger, receiver OpusFrameReceiver, conn Conn) AudioReceiver {
+		receiverCreateCount.Add(1)
+		r := &fakeAudioReceiver{}
+		lastReceiver = r
+		return r
+	}
+
+	conn := &connImpl{
+		config: connConfig{
+			Logger:                  slog.Default(),
+			AudioSenderCreateFunc:   senderCreateFunc,
+			AudioReceiverCreateFunc: receiverCreateFunc,
+		},
+		openedChan: make(chan struct{}, 1),
+		udp:        &fakeUDPConn{},
+	}
+
+	// Simulate user setting up audio pipeline before any reconnect.
+	conn.SetOpusFrameProvider(&fakeOpusFrameProvider{})
+	conn.SetOpusFrameReceiver(&fakeOpusFrameReceiver{})
+
+	if c := senderCreateCount.Load(); c != 1 {
+		t.Fatalf("expected 1 sender create after SetOpusFrameProvider, got %d", c)
+	}
+	if c := receiverCreateCount.Load(); c != 1 {
+		t.Fatalf("expected 1 receiver create after SetOpusFrameReceiver, got %d", c)
+	}
+
+	firstSender := lastSender
+	firstReceiver := lastReceiver
+
+	// Simulate a SessionDescription arriving after reconnect (Identify path).
+	// This should restart the audio sender and receiver.
+	conn.handleMessage(nil, OpcodeSessionDescription, 0, GatewayMessageDataSessionDescription{
+		Mode:      EncryptionModeAEADXChaCha20Poly1305RTPSize,
+		SecretKey: make([]byte, 32),
+	})
+
+	// Verify the old sender/receiver were closed.
+	if !firstSender.closed.Load() {
+		t.Error("expected old audio sender to be closed after SessionDescription")
+	}
+	if !firstReceiver.closed.Load() {
+		t.Error("expected old audio receiver to be closed after SessionDescription")
+	}
+
+	// Verify new instances were created.
+	if c := senderCreateCount.Load(); c != 2 {
+		t.Errorf("expected 2 total sender creates (initial + restart), got %d", c)
+	}
+	if c := receiverCreateCount.Load(); c != 2 {
+		t.Errorf("expected 2 total receiver creates (initial + restart), got %d", c)
+	}
+
+	// Drain the openedChan signal.
+	select {
+	case <-conn.openedChan:
+	default:
+		t.Error("expected openedChan to be signaled after SessionDescription")
+	}
+}
+
+func TestHandleMessage_SessionDescription_NoRestartWithoutPriorSetup(t *testing.T) {
+	var (
+		senderCreateCount   atomic.Int32
+		receiverCreateCount atomic.Int32
+	)
+
+	senderCreateFunc := func(logger *slog.Logger, provider OpusFrameProvider, conn Conn) AudioSender {
+		senderCreateCount.Add(1)
+		return &fakeAudioSender{}
+	}
+
+	receiverCreateFunc := func(logger *slog.Logger, receiver OpusFrameReceiver, conn Conn) AudioReceiver {
+		receiverCreateCount.Add(1)
+		return &fakeAudioReceiver{}
+	}
+
+	conn := &connImpl{
+		config: connConfig{
+			Logger:                  slog.Default(),
+			AudioSenderCreateFunc:   senderCreateFunc,
+			AudioReceiverCreateFunc: receiverCreateFunc,
+		},
+		openedChan: make(chan struct{}, 1),
+		udp:        &fakeUDPConn{},
+	}
+
+	// Do NOT call SetOpusFrameProvider/SetOpusFrameReceiver.
+	// SessionDescription should not create any audio sender/receiver.
+	conn.handleMessage(nil, OpcodeSessionDescription, 0, GatewayMessageDataSessionDescription{
+		Mode:      EncryptionModeAEADXChaCha20Poly1305RTPSize,
+		SecretKey: make([]byte, 32),
+	})
+
+	if c := senderCreateCount.Load(); c != 0 {
+		t.Errorf("expected 0 sender creates without prior SetOpusFrameProvider, got %d", c)
+	}
+	if c := receiverCreateCount.Load(); c != 0 {
+		t.Errorf("expected 0 receiver creates without prior SetOpusFrameReceiver, got %d", c)
+	}
+}

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -102,18 +102,21 @@ func NewGateway(daveSession godave.Session, eventHandlerFunc EventHandlerFunc, c
 	cfg := defaultGatewayConfig()
 	cfg.apply(opts)
 
-	return &gatewayImpl{
+	g := &gatewayImpl{
 		config:           cfg,
 		daveSession:      daveSession,
 		eventHandlerFunc: eventHandlerFunc,
 		closeHandlerFunc: closeHandlerFunc,
 	}
+	g.openFunc = g.open
+	return g
 }
 
 type gatewayImpl struct {
 	config           gatewayConfig
 	eventHandlerFunc EventHandlerFunc
 	closeHandlerFunc CloseHandlerFunc
+	openFunc         func(ctx context.Context, state State) error
 
 	ssrc  uint32
 	state State
@@ -324,7 +327,7 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State) error {
 		case <-timer.C:
 		}
 
-		err := g.open(ctx, state)
+		err := g.openFunc(ctx, state)
 		if err == nil {
 			// Successfully connected, our job here is done
 			return nil
@@ -337,7 +340,11 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State) error {
 		var closeError *websocket.CloseError
 		if errors.As(err, &closeError) {
 			closeCode := GatewayCloseEventCodeByCode(closeError.Code)
-			if !closeCode.Reconnect {
+			// 4006 means the resume was rejected because the session expired,
+			// but a fresh Identify may succeed. The resume state (ssrc/seq)
+			// was already cleared by open() -> Close(), so the next attempt
+			// will send Identify instead of Resume. Let it fall through to retry.
+			if !closeCode.Reconnect && closeError.Code != GatewayCloseEventCodeSessionNoLongerValid.Code {
 				return err
 			}
 		}

--- a/voice/gateway_test.go
+++ b/voice/gateway_test.go
@@ -1,0 +1,119 @@
+package voice
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/gorilla/websocket"
+)
+
+func newTestGateway() *gatewayImpl {
+	cfg := defaultGatewayConfig()
+	cfg.AutoReconnect = true
+	gw := &gatewayImpl{config: cfg}
+	gw.openFunc = gw.open // default; tests override this
+	return gw
+}
+
+func testState() State {
+	channelID := snowflake.ID(1)
+	return State{
+		GuildID:   snowflake.ID(1),
+		UserID:    snowflake.ID(2),
+		ChannelID: &channelID,
+		SessionID: "test-session",
+		Token:     "test-token",
+		Endpoint:  "localhost:1234",
+	}
+}
+
+func TestDoReconnect_FallsBackToIdentifyAfter4006(t *testing.T) {
+	gw := newTestGateway()
+
+	// Pre-set resume state to simulate a previously established session.
+	gw.ssrc = 12345
+	gw.seq = 10
+
+	var calls atomic.Int32
+
+	gw.openFunc = func(ctx context.Context, state State) error {
+		n := calls.Add(1)
+		switch n {
+		case 1:
+			// First call: simulate what open() does when Discord rejects
+			// a Resume with 4006. open() clears ssrc/seq via Close(), then
+			// returns the close error.
+			gw.ssrc = 0
+			gw.seq = 0
+			return &websocket.CloseError{
+				Code: GatewayCloseEventCodeSessionNoLongerValid.Code,
+				Text: "Session is no longer valid.",
+			}
+		case 2:
+			// Second call: the retry. Verify resume state was cleared so
+			// a real open() would send Identify. Simulate success.
+			if gw.ssrc != 0 || gw.seq != 0 {
+				t.Errorf("expected ssrc=0 seq=0 on retry, got ssrc=%d seq=%d", gw.ssrc, gw.seq)
+			}
+			return nil
+		default:
+			t.Fatalf("unexpected call %d to openFunc", n)
+			return nil
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := gw.doReconnect(ctx, testState())
+	if err != nil {
+		t.Fatalf("doReconnect returned error: %v", err)
+	}
+	if c := calls.Load(); c != 2 {
+		t.Errorf("expected 2 calls to openFunc, got %d", c)
+	}
+}
+
+func TestDoReconnect_StillFailsOnTrulyNonReconnectableCodes(t *testing.T) {
+	testCases := []struct {
+		name string
+		code int
+	}{
+		{"4003 Not Authenticated", 4003},
+		{"4004 Authentication Failed", 4004},
+		{"4009 Session Timeout", 4009},
+		{"4011 Server Not Found", 4011},
+		{"4014 Disconnected", 4014},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := newTestGateway()
+
+			var calls atomic.Int32
+
+			gw.openFunc = func(ctx context.Context, state State) error {
+				calls.Add(1)
+				return &websocket.CloseError{
+					Code: tc.code,
+					Text: fmt.Sprintf("close code %d", tc.code),
+				}
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			err := gw.doReconnect(ctx, testState())
+			if err == nil {
+				t.Fatalf("expected doReconnect to return error for close code %d, got nil", tc.code)
+			}
+			if c := calls.Load(); c != 1 {
+				t.Errorf("expected 1 call to openFunc for code %d, got %d", tc.code, c)
+			}
+		})
+	}
+}

--- a/voice/udp_conn.go
+++ b/voice/udp_conn.go
@@ -190,6 +190,13 @@ func (u *udpConnImpl) SetWriteDeadline(t time.Time) error {
 func (u *udpConnImpl) Open(ctx context.Context, ip string, port int, ssrc uint32) (string, int, error) {
 	u.connMu.Lock()
 	defer u.connMu.Unlock()
+
+	// Close any existing connection so that readers (e.g. audio receiver)
+	// get an error and can be restarted on the new connection.
+	if u.conn != nil {
+		_ = u.conn.Close()
+	}
+
 	host := net.JoinHostPort(ip, strconv.Itoa(port))
 	u.config.Logger.Debug("Opening UDPConn connection", slog.String("host", host))
 	var err error


### PR DESCRIPTION
When a voice gateway drops and the reconnect's Resume is rejected with close code 4006 ("Session is no longer valid"), doReconnect treated it as non-reconnectable and gave up. This tore down the entire voice connection and the bot stopped receiving audio.

Gateway fix (voice/gateway.go): Exempt 4006 from the non-reconnectable bail-out in doReconnect. Since open() already clears resume state (ssrc/seq) on failure, the retry naturally sends Identify instead of Resume. Also made open() injectable (openFunc) for testability.

Audio pipeline fix (voice/conn.go, voice/udp_conn.go): The Identify path produces a new Ready → new UDP socket, but the audio sender/receiver goroutines were still reading from the old one. Two changes:
- udpConnImpl.Open() now closes the previous net.Conn before dialing a new one (prevents socket leak, unblocks stale readers)
- connImpl.handleMessage restarts the audio sender/receiver on SessionDescription if they were previously configured