### PR TITLE
feat(rest): add JSON error code `160014`

### DIFF
--- a/rest/rest_error.go
+++ b/rest/rest_error.go
@@ -250,6 +250,9 @@ const (
 	JSONErrorCodeMaximumActiveThreadsReached                    JSONErrorCode = 160006
 	JSONErrorCodeMaximumActiveAnnouncementThreadsReached        JSONErrorCode = 160007
 
+	// Cannot forward message with unreadable content
+	JSONErrorCodeCannotForwardMessageWithUnreadableContent JSONErrorCode = 160014
+
 	// Lottie/sticker errors
 	JSONErrorCodeInvalidJSONForUploadedLottieFile             JSONErrorCode = 170001
 	JSONErrorCodeUploadedLottiesCannotContainRasterizedImages JSONErrorCode = 170002


### PR DESCRIPTION
Add JSON error code `160014` for messages that cannot be forwarded due to unreadable content.

Discord API Docs reference: 
- https://github.com/discord/discord-api-docs/pull/8295