### PR TITLE
fix(discord): remove unsupported negated `MessageSearchEmbedType`

### DIFF
--- a/discord/guild.go
+++ b/discord/guild.go
@@ -447,13 +447,6 @@ const (
 	MessageSearchEmbedTypeGif     MessageSearchEmbedType = "gif"
 	MessageSearchEmbedTypeSound   MessageSearchEmbedType = "sound"
 	MessageSearchEmbedTypeArticle MessageSearchEmbedType = "article"
-
-	// Negated types, results will not include messages that have these embed types.
-	MessageSearchEmbedTypeNotImage   MessageSearchEmbedType = "-" + MessageSearchEmbedTypeImage
-	MessageSearchEmbedTypeNotVideo   MessageSearchEmbedType = "-" + MessageSearchEmbedTypeVideo
-	MessageSearchEmbedTypeNotGif     MessageSearchEmbedType = "-" + MessageSearchEmbedTypeGif
-	MessageSearchEmbedTypeNotSound   MessageSearchEmbedType = "-" + MessageSearchEmbedTypeSound
-	MessageSearchEmbedTypeNotArticle MessageSearchEmbedType = "-" + MessageSearchEmbedTypeArticle
 )
 
 // MessageSearchSortBy is the field to sort search results by.


### PR DESCRIPTION
Message search embed types are not negatable.

Discord API Docs reference:
- https://docs.discord.com/developers/resources/message#search-guild-messages-search-embed-types

Spec reference:
https://github.com/discord/discord-api-spec/blob/main/specs/openapi.json#L35521-L35545