### PR TITLE
feat(event_collector): run filterFunc in a goroutine to avoid blocking

### DIFF
--- a/bot/event_collector.go
+++ b/bot/event_collector.go
@@ -30,10 +30,12 @@ func NewEventCollector[E Event](client *Client, filterFunc func(e E) bool) (<-ch
 	var once sync.Once
 
 	handler := NewListenerFunc(func(e E) {
-		if !filterFunc(e) {
-			return
-		}
-		ch <- e
+		go func() {
+			if !filterFunc(e) {
+				return
+			}
+			ch <- e
+		}()
 	})
 	client.EventManager.AddEventListeners(handler)
 


### PR DESCRIPTION
Blocking operations (e.g. db calls) inside `filterFunc` currently block the entire event manager loop, since filters run synchronously in the event listener.