### PR TITLE
feat(OAuth2Scope): add `OAuth2ScopeIdentifyPremium` scope

### DIFF
--- a/discord/application.go
+++ b/discord/application.go
@@ -127,6 +127,7 @@ const (
 	OAuth2ScopeRelationshipsRead    OAuth2Scope = "relationships.read"
 	OAuth2ScopeRoleConnectionsWrite OAuth2Scope = "role_connections.write"
 	OAuth2ScopeIdentify             OAuth2Scope = "identify"
+	OAuth2ScopeIdentifyPremium      OAuth2Scope = "identify.premium"
 	OAuth2ScopeEmail                OAuth2Scope = "email"
 	OAuth2ScopeConnections          OAuth2Scope = "connections"
 	OAuth2ScopeBot                  OAuth2Scope = "bot"

--- a/discord/user.go
+++ b/discord/user.go
@@ -178,9 +178,11 @@ func (u User) CreatedAt() time.Time {
 type OAuth2User struct {
 	User
 	// Requires OAuth2ScopeIdentify
-	MfaEnabled  bool        `json:"mfa_enabled"`
-	Locale      string      `json:"locale"`
-	Flags       UserFlags   `json:"flags"`
+	MfaEnabled bool      `json:"mfa_enabled"`
+	Locale     string    `json:"locale"`
+	Flags      UserFlags `json:"flags"`
+
+	// Requires OAuth2ScopeIdentifyPremium
 	PremiumType PremiumType `json:"premium_type"`
 
 	// Requires OAuth2ScopeEmail


### PR DESCRIPTION
Add `OAuth2ScopeIdentifyPremium` for `identify.premium` OAuth2 scope.

Discord API Docs reference:
- https://github.com/discord/discord-api-docs/pull/8340