### PR TITLE
fix(voice): Conn.Close blocking forever

### DIFF
--- a/voice/conn.go
+++ b/voice/conn.go
@@ -292,10 +292,9 @@ func (c *connImpl) Open(ctx context.Context, channelID snowflake.ID, selfMute bo
 
 func (c *connImpl) Close(ctx context.Context) {
 	_ = c.voiceStateUpdateFunc(ctx, c.state.GuildID, nil, false, false)
-	defer c.gateway.Close()
-	defer func() {
-		_ = c.udp.Close()
-	}()
+
+	c.gateway.Close()
+	_ = c.udp.Close()
 
 	select {
 	case _, ok := <-c.closedChan:

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -187,7 +187,11 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 		}
 		_ = c.udp.Close()
 		c.gateway.Close()
-		c.closedChan <- struct{}{}
+
+		select {
+		case c.closedChan <- struct{}{}:
+		default:
+		}
 	} else {
 		c.state.ChannelID = update.ChannelID
 	}
@@ -296,12 +300,5 @@ func (c *connImpl) Close(ctx context.Context) {
 	c.gateway.Close()
 	_ = c.udp.Close()
 
-	select {
-	case _, ok := <-c.closedChan:
-		if ok {
-			close(c.closedChan)
-		}
-	case <-ctx.Done():
-	}
 	c.removeConnFunc()
 }

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -185,7 +185,6 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 		}
 		_ = c.udp.Close()
 		c.gateway.Close()
-
 	} else {
 		c.state.ChannelID = update.ChannelID
 	}

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -73,7 +73,6 @@ func NewConn(guildID snowflake.ID, userID snowflake.ID, voiceStateUpdateFunc Sta
 			UserID:  userID,
 		},
 		openedChan: make(chan struct{}, 1),
-		closedChan: make(chan struct{}, 1),
 		ssrcs:      map[uint32]snowflake.ID{},
 	}
 
@@ -99,7 +98,6 @@ type connImpl struct {
 	audioReceiver AudioReceiver
 
 	openedChan chan struct{}
-	closedChan chan struct{}
 
 	ssrcs   map[uint32]snowflake.ID
 	ssrcsMu sync.Mutex
@@ -188,10 +186,6 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 		_ = c.udp.Close()
 		c.gateway.Close()
 
-		select {
-		case c.closedChan <- struct{}{}:
-		default:
-		}
 	} else {
 		c.state.ChannelID = update.ChannelID
 	}


### PR DESCRIPTION
`connImpl.Close()` deferred `gateway.Close()` and `udp.Close()` to after a `select` that waited on `c.closedChan`. The channel was only filled by `HandleVoiceStateUpdate` when Discord confirmed the voice leave.

In linkdave's case, `voiceStateUpdateFunc` is a no-op — so Discord never received the leave and `closedChan` was never signaled. `Close()` blocked until context timeout, with all resources still open during the wait.

I verified this behavior with a [modified version of linkdave](https://github.com/shi-gg/linkdave/blob/main/server/voice/connection.go#L76-L80) using `oldVC.Close(context.Background())`.


https://github.com/user-attachments/assets/4f82aedb-e29b-43d9-a8e2-f9e557d3b25b

