### PR TITLE
feat: add new fields and flags

### DIFF
--- a/discord/attachment.go
+++ b/discord/attachment.go
@@ -8,20 +8,23 @@ import (
 
 // Attachment is used for files sent in a Message
 type Attachment struct {
-	ID           snowflake.ID    `json:"id,omitempty"`
-	Filename     string          `json:"filename,omitempty"`
-	Title        *string         `json:"title,omitempty"`
-	Description  *string         `json:"description,omitempty"`
-	ContentType  *string         `json:"content_type,omitempty"`
-	Size         int             `json:"size,omitempty"`
-	URL          string          `json:"url,omitempty"`
-	ProxyURL     string          `json:"proxy_url,omitempty"`
-	Height       *int            `json:"height,omitempty"`
-	Width        *int            `json:"width,omitempty"`
-	Ephemeral    bool            `json:"ephemeral,omitempty"`
-	DurationSecs *float64        `json:"duration_secs,omitempty"`
-	Waveform     *string         `json:"waveform,omitempty"`
-	Flags        AttachmentFlags `json:"flags"`
+	ID               snowflake.ID    `json:"id,omitempty"`
+	Filename         string          `json:"filename,omitempty"`
+	Title            *string         `json:"title,omitempty"`
+	Description      *string         `json:"description,omitempty"`
+	ContentType      *string         `json:"content_type,omitempty"`
+	Size             int             `json:"size,omitempty"`
+	URL              string          `json:"url,omitempty"`
+	ProxyURL         string          `json:"proxy_url,omitempty"`
+	Height           *int            `json:"height,omitempty"`
+	Width            *int            `json:"width,omitempty"`
+	Ephemeral        bool            `json:"ephemeral,omitempty"`
+	DurationSecs     *float64        `json:"duration_secs,omitempty"`
+	Waveform         *string         `json:"waveform,omitempty"`
+	Flags            AttachmentFlags `json:"flags"`
+	ClipParticipants []User          `json:"clip_participants,omitempty"`
+	ClipCreatedAt    time.Time       `json:"clip_created_at,omitzero"`
+	Application      *Application    `json:"application,omitempty"`
 }
 
 func (a Attachment) CreatedAt() time.Time {
@@ -34,6 +37,9 @@ const (
 	AttachmentFlagIsClip AttachmentFlags = 1 << iota
 	AttachmentFlagIsThumbnail
 	AttachmentFlagIsRemix
+	AttachmentFlagIsSpoiler
+	_
+	AttachmentFlagIsAnimated
 	AttachmentFlagsNone AttachmentFlags = 0
 )
 

--- a/discord/component.go
+++ b/discord/component.go
@@ -749,17 +749,32 @@ type UnfurledMediaItem struct {
 	URL string `json:"url"`
 	// ProxyURL is a proxied version of the URL. This can't be set by bots.
 	ProxyURL string `json:"proxy_url,omitempty"`
-	// Height is the height of the media item in pixels. This can't be set by bots.
+	// Height is the height of the media item (if image or video) in pixels. This can't be set by bots.
 	Height int `json:"height,omitempty"`
-	// Width is the width of the media item in pixels. This can't be set by bots.
+	// Width is the width of the media item (if image or video) in pixels. This can't be set by bots.
 	Width int `json:"width,omitempty"`
+	// Placeholder is the [Thumbhash] placeholder (if image or video). This can't be set by bots.
+	//
+	// [Thumbhash]: https://evanw.github.io/thumbhash/
+	Placeholder string `json:"placeholder,omitempty"`
+	// PlaceholderVersion is the version of the placeholder (if image or video). This can't be set by bots.
+	PlaceholderVersion int `json:"placeholder_version,omitempty"`
 	// ContentType is the content type of the media item. This can't be set by bots.
 	ContentType string `json:"content_type,omitempty"`
+	// Flags is the unfurled media item flags combined as a bitfield. This can't be set by bots.
+	Flags UnfurledMediaItemFlags `json:"flags"`
 	// AttachmentID is the id of the uploaded attachment. This can't be set by bots.
 	AttachmentID snowflake.ID `json:"attachment_id,omitempty"`
 	// LoadingState is the loading state of the media item. This can't be set by bots.
 	LoadingState UnfurledMediaItemLoadingState `json:"loading_state,omitempty"`
 }
+
+type UnfurledMediaItemFlags int
+
+const (
+	UnfurledMediaItemFlagIsAnimated UnfurledMediaItemFlags = 1 << iota
+	UnfurledMediaItemFlagsNone      UnfurledMediaItemFlags = 0
+)
 
 // NewSection creates a new [SectionComponent] with the provided components.
 func NewSection(components ...SectionSubComponent) SectionComponent {

--- a/discord/embed.go
+++ b/discord/embed.go
@@ -42,7 +42,15 @@ type Embed struct {
 	Provider    *EmbedProvider `json:"provider,omitempty"`
 	Author      *EmbedAuthor   `json:"author,omitempty"`
 	Fields      []EmbedField   `json:"fields,omitempty"`
+	Flags       EmbedFlags     `json:"flags,omitempty"`
 }
+
+type EmbedFlags int
+
+const (
+	EmbedFlagsNone                   EmbedFlags = 0
+	EmbedFlagIsContentInventoryEntry EmbedFlags = 1 << 5
+)
 
 // WithTitle Withs the title of the Embed
 func (e Embed) WithTitle(title string) Embed {


### PR DESCRIPTION
Changes:
- Add missing fields and flags for `Attachment`
- Add missing fields and flags for `UnfurledMediaItem`
- Add flags for `Embed`

Discord API docs reference:
https://github.com/discord/discord-api-docs/commit/06c6560196692af7fe808c582bfd34c60a8b4ea1