### PR TITLE
feat(discord): add missing `placeholder` on `Attachment`

### DIFF
--- a/discord/attachment.go
+++ b/discord/attachment.go
@@ -8,23 +8,25 @@ import (
 
 // Attachment is used for files sent in a Message
 type Attachment struct {
-	ID               snowflake.ID    `json:"id,omitempty"`
-	Filename         string          `json:"filename,omitempty"`
-	Title            *string         `json:"title,omitempty"`
-	Description      *string         `json:"description,omitempty"`
-	ContentType      *string         `json:"content_type,omitempty"`
-	Size             int             `json:"size,omitempty"`
-	URL              string          `json:"url,omitempty"`
-	ProxyURL         string          `json:"proxy_url,omitempty"`
-	Height           *int            `json:"height,omitempty"`
-	Width            *int            `json:"width,omitempty"`
-	Ephemeral        bool            `json:"ephemeral,omitempty"`
-	DurationSecs     *float64        `json:"duration_secs,omitempty"`
-	Waveform         *string         `json:"waveform,omitempty"`
-	Flags            AttachmentFlags `json:"flags"`
-	ClipParticipants []User          `json:"clip_participants,omitempty"`
-	ClipCreatedAt    time.Time       `json:"clip_created_at,omitzero"`
-	Application      *Application    `json:"application,omitempty"`
+	ID                 snowflake.ID    `json:"id,omitempty"`
+	Filename           string          `json:"filename,omitempty"`
+	Title              *string         `json:"title,omitempty"`
+	Description        *string         `json:"description,omitempty"`
+	ContentType        *string         `json:"content_type,omitempty"`
+	Size               int             `json:"size,omitempty"`
+	URL                string          `json:"url,omitempty"`
+	ProxyURL           string          `json:"proxy_url,omitempty"`
+	Height             *int            `json:"height,omitempty"`
+	Width              *int            `json:"width,omitempty"`
+	Placeholder        string          `json:"placeholder,omitempty"`
+	PlaceholderVersion int             `json:"placeholder_version,omitempty"`
+	Ephemeral          bool            `json:"ephemeral,omitempty"`
+	DurationSecs       *float64        `json:"duration_secs,omitempty"`
+	Waveform           *string         `json:"waveform,omitempty"`
+	Flags              AttachmentFlags `json:"flags"`
+	ClipParticipants   []User          `json:"clip_participants,omitempty"`
+	ClipCreatedAt      time.Time       `json:"clip_created_at,omitzero"`
+	Application        *Application    `json:"application,omitempty"`
 }
 
 func (a Attachment) CreatedAt() time.Time {


### PR DESCRIPTION
adds `Placeholder` and `PlaceholderVersion` to match [the docs](https://docs.discord.com/developers/resources/message#attachment-object) and existing implementation patterns in embed.go:

https://github.com/disgoorg/disgo/blob/18dc4c22f87508aa9778631c163a2ec0682b08a5/discord/embed.go#L326-L327

<img width="374" height="374" alt="tudou-tudou-dance (1)" src="https://github.com/user-attachments/assets/81c3ef98-45d6-486c-88c1-d8105c28dfe6" />
