### PR TITLE
fix(voice): nil-guard udpConnImpl.Close to prevent SIGSEGV on un-opened conn

### DIFF
--- a/voice/udp_conn.go
+++ b/voice/udp_conn.go
@@ -398,5 +398,8 @@ func (u *udpConnImpl) ReadPacket() (*Packet, error) {
 func (u *udpConnImpl) Close() error {
 	u.connMu.Lock()
 	defer u.connMu.Unlock()
+	if u.conn == nil {
+		return nil
+	}
 	return u.conn.Close()
 }


### PR DESCRIPTION
## Summary

Fixes a nil-pointer panic in `(*udpConnImpl).Close()` when called before `Open()` has assigned `u.conn`.

`(*connImpl).HandleVoiceStateUpdate` unconditionally calls `c.udp.Close()` whenever a `VOICE_STATE_UPDATE` arrives with `ChannelID == nil` (the bot was kicked, moved, or its session was torn down before voice negotiation completed). If the UDP connection was never opened, `u.conn` is still `nil` and the bare `return u.conn.Close()` panics with a SIGSEGV, taking down the entire gateway listener goroutine.

The fix adds a nil-check so `Close()` is safe to call on an un-opened UDP conn — matching the defensive `if c.audioSender != nil { ... }` and `if c.audioReceiver != nil { ... }` guards already present on the surrounding lines of `HandleVoiceStateUpdate`.

### Stack (reproduced against v0.19.5)

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x10301d654]

goroutine 85 [running]:
github.com/disgoorg/disgo/voice.(*udpConnImpl).Close(...)
        voice/udp_conn.go:401 +0xa4
github.com/disgoorg/disgo/voice.(*connImpl).HandleVoiceStateUpdate(...)
        voice/conn.go:186 +0x110
github.com/disgoorg/disgo/voice.(*managerImpl).HandleVoiceStateUpdate(...)
        voice/manager.go:72 +0xf4
github.com/disgoorg/disgo/bot/handlers.gatewayHandlerVoiceStateUpdate(...)
        bot/handlers/voice_handlers.go:28 +0x294
...
```

## Test plan

- [x] `go build ./...` in disgo and a downstream voice-bot consumer
- [x] Downstream integration tests that previously SIGSEGV'd within ~30s now run to completion