### PR TITLE
fix(voice): voice open without ChannelID

### DIFF
--- a/voice/conn.go
+++ b/voice/conn.go
@@ -99,8 +99,6 @@ type connImpl struct {
 
 	openedChan chan struct{}
 
-	opening bool
-
 	ssrcs   map[uint32]snowflake.ID
 	ssrcsMu sync.Mutex
 }
@@ -210,51 +208,15 @@ func (c *connImpl) HandleVoiceServerUpdate(update botgateway.EventVoiceServerUpd
 	c.tryOpenGateway()
 }
 
-func (c *connImpl) canOpen() bool {
-	if c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == nil {
-		return false
-	}
-	status := c.gateway.Status()
-	return status == StatusUnconnected || status == StatusDisconnected
-}
-
 func (c *connImpl) tryOpenGateway() {
-	if c.opening || !c.canOpen() {
+	if c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == nil {
 		return
 	}
-	c.opening = true
-	state := c.state
 	go func() {
-		parentCtx, parentCancel := context.WithTimeout(context.Background(), 2*maximumConnectDelay)
-		defer func() {
-			c.stateMu.Lock()
-			c.opening = false
-			c.stateMu.Unlock()
-			parentCancel()
-		}()
-		for {
-			if parentCtx.Err() != nil {
-				return
-			}
-			ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
-			err := c.gateway.Open(ctx, state)
-			cancel()
-			if err != nil {
-				c.config.Logger.Error("error opening voice gateway", slog.Any("err", err))
-			}
-			c.stateMu.Lock()
-			if !c.canOpen() {
-				c.stateMu.Unlock()
-				return
-			}
-			if c.state.Token == state.Token &&
-				c.state.Endpoint == state.Endpoint &&
-				*c.state.ChannelID == *state.ChannelID {
-				c.stateMu.Unlock()
-				return
-			}
-			state = c.state
-			c.stateMu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := c.gateway.Open(ctx, c.state); err != nil {
+			c.config.Logger.Error("error opening voice gateway", slog.Any("err", err))
 		}
 	}()
 }

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -120,7 +120,13 @@ func (c *connImpl) SendInvalidCommitWelcome(transitionID uint16) error {
 }
 
 func (c *connImpl) ChannelID() *snowflake.ID {
-	return c.state.ChannelID
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if c.state.ChannelID == 0 {
+		return nil
+	}
+	channelID := c.state.ChannelID
+	return &channelID
 }
 
 func (c *connImpl) GuildID() snowflake.ID {
@@ -173,8 +179,11 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 		return
 	}
 
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+
 	if update.ChannelID == nil {
-		c.state.ChannelID = nil
+		c.state.ChannelID = 0
 		if c.audioSender != nil {
 			c.audioSender.Close()
 			c.audioSender = nil
@@ -186,13 +195,11 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 		_ = c.udp.Close()
 		c.gateway.Close()
 	} else {
-		c.state.ChannelID = update.ChannelID
+		c.state.ChannelID = *update.ChannelID
 	}
 	c.state.SessionID = update.SessionID
 
-	c.stateMu.Lock()
 	c.tryOpenGateway()
-	c.stateMu.Unlock()
 }
 
 func (c *connImpl) HandleVoiceServerUpdate(update botgateway.EventVoiceServerUpdate) {
@@ -209,13 +216,14 @@ func (c *connImpl) HandleVoiceServerUpdate(update botgateway.EventVoiceServerUpd
 }
 
 func (c *connImpl) tryOpenGateway() {
-	if c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == nil {
+	if c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == 0 {
 		return
 	}
+	state := c.state
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := c.gateway.Open(ctx, c.state); err != nil {
+		if err := c.gateway.Open(ctx, state); err != nil {
 			c.config.Logger.Error("error opening voice gateway", slog.Any("err", err))
 		}
 	}()

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -99,6 +99,8 @@ type connImpl struct {
 
 	openedChan chan struct{}
 
+	opening bool
+
 	ssrcs   map[uint32]snowflake.ID
 	ssrcsMu sync.Mutex
 }
@@ -189,6 +191,10 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 		c.state.ChannelID = update.ChannelID
 	}
 	c.state.SessionID = update.SessionID
+
+	c.stateMu.Lock()
+	c.tryOpenGateway()
+	c.stateMu.Unlock()
 }
 
 func (c *connImpl) HandleVoiceServerUpdate(update botgateway.EventVoiceServerUpdate) {
@@ -200,11 +206,55 @@ func (c *connImpl) HandleVoiceServerUpdate(update botgateway.EventVoiceServerUpd
 
 	c.state.Token = update.Token
 	c.state.Endpoint = *update.Endpoint
+
+	c.tryOpenGateway()
+}
+
+func (c *connImpl) canOpen() bool {
+	if c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == nil {
+		return false
+	}
+	status := c.gateway.Status()
+	return status == StatusUnconnected || status == StatusDisconnected
+}
+
+func (c *connImpl) tryOpenGateway() {
+	if c.opening || !c.canOpen() {
+		return
+	}
+	c.opening = true
+	state := c.state
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := c.gateway.Open(ctx, c.state); err != nil {
-			c.config.Logger.Error("error opening voice gateway", slog.Any("err", err))
+		parentCtx, parentCancel := context.WithTimeout(context.Background(), 2*maximumConnectDelay)
+		defer func() {
+			c.stateMu.Lock()
+			c.opening = false
+			c.stateMu.Unlock()
+			parentCancel()
+		}()
+		for {
+			if parentCtx.Err() != nil {
+				return
+			}
+			ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+			err := c.gateway.Open(ctx, state)
+			cancel()
+			if err != nil {
+				c.config.Logger.Error("error opening voice gateway", slog.Any("err", err))
+			}
+			c.stateMu.Lock()
+			if !c.canOpen() {
+				c.stateMu.Unlock()
+				return
+			}
+			if c.state.Token == state.Token &&
+				c.state.Endpoint == state.Endpoint &&
+				*c.state.ChannelID == *state.ChannelID {
+				c.stateMu.Unlock()
+				return
+			}
+			state = c.state
+			c.stateMu.Unlock()
 		}
 	}()
 }

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -32,9 +32,6 @@ var (
 
 	// ErrGatewayAlreadyConnected is returned when the gateway is already connected and a connection is attempted to be opened.
 	ErrGatewayAlreadyConnected = fmt.Errorf("voice gateway already connected")
-
-	// ErrGatewayNoChannelID is returned from Open when the supplied State has a nil ChannelID; the DAVE session cannot be keyed without a channel.
-	ErrGatewayNoChannelID = fmt.Errorf("voice gateway state has no channel ID")
 )
 
 // Status returns the current status of the gateway.
@@ -70,7 +67,7 @@ type State struct {
 	GuildID snowflake.ID
 	UserID  snowflake.ID
 
-	ChannelID *snowflake.ID
+	ChannelID snowflake.ID
 	SessionID string
 	Token     string
 	Endpoint  string
@@ -146,10 +143,6 @@ func (g *gatewayImpl) Open(ctx context.Context, state State) error {
 func (g *gatewayImpl) open(ctx context.Context, state State) error {
 	g.config.Logger.Debug("opening voice gateway connection")
 
-	if state.ChannelID == nil {
-		return ErrGatewayNoChannelID
-	}
-
 	g.connMu.Lock()
 	if g.conn != nil {
 		g.connMu.Unlock()
@@ -187,7 +180,7 @@ func (g *gatewayImpl) open(ctx context.Context, state State) error {
 		return nil
 	})
 
-	g.daveSession.SetChannelID(godave.ChannelID(*state.ChannelID))
+	g.daveSession.SetChannelID(godave.ChannelID(state.ChannelID))
 	g.conn = conn
 	g.connMu.Unlock()
 
@@ -337,7 +330,7 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State) error {
 			return nil
 		}
 
-		if errors.Is(err, discord.ErrGatewayAlreadyConnected) || errors.Is(err, ErrGatewayNoChannelID) {
+		if errors.Is(err, discord.ErrGatewayAlreadyConnected) {
 			return err
 		}
 

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -32,6 +32,9 @@ var (
 
 	// ErrGatewayAlreadyConnected is returned when the gateway is already connected and a connection is attempted to be opened.
 	ErrGatewayAlreadyConnected = fmt.Errorf("voice gateway already connected")
+
+	// ErrGatewayNoChannelID is returned from Open when the supplied State has a nil ChannelID; the DAVE session cannot be keyed without a channel.
+	ErrGatewayNoChannelID = fmt.Errorf("voice gateway state has no channel ID")
 )
 
 // Status returns the current status of the gateway.
@@ -142,6 +145,10 @@ func (g *gatewayImpl) Open(ctx context.Context, state State) error {
 
 func (g *gatewayImpl) open(ctx context.Context, state State) error {
 	g.config.Logger.Debug("opening voice gateway connection")
+
+	if state.ChannelID == nil {
+		return ErrGatewayNoChannelID
+	}
 
 	g.connMu.Lock()
 	if g.conn != nil {
@@ -330,7 +337,7 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State) error {
 			return nil
 		}
 
-		if errors.Is(err, discord.ErrGatewayAlreadyConnected) {
+		if errors.Is(err, discord.ErrGatewayAlreadyConnected) || errors.Is(err, ErrGatewayNoChannelID) {
 			return err
 		}
 


### PR DESCRIPTION

## Summary

`gateway.open` at `voice/gateway.go:183` bare-derefs `*state.ChannelID`. It SIGSEGVs when VOICE_SERVER_UPDATE arrives before VOICE_STATE_UPDATE (no strict ordering on reconnect/resume), or when a kick nils `ChannelID` while a VSU goroutine is in flight.

## Design

Required inputs are split across two events — VSU carries `Token` + `Endpoint`, VStateU carries `ChannelID` — and the order isn't guaranteed. Both handlers now call a small `tryOpenGateway` helper that checks "all three present" and spawns one open goroutine with a value-captured `state`. Whichever event arrives second triggers the open.

If both events arrive close enough to spawn two opens, the second goroutine gets `ErrGatewayAlreadyConnected` from `gateway.Open` and logs once.

`gateway.open` also returns a new `ErrGatewayNoChannelID` sentinel when `state.ChannelID == nil`, as defense-in-depth for external `Gateway` consumers that bypass `Conn`. `doReconnect` treats it as terminal alongside `ErrGatewayAlreadyConnected`.

### Effect on each ordering

| Scenario | Old | This PR |
|---|---|---|
| VStateU → VSU | works | works |
| VSU → VStateU | nil-deref | works |
| VSU with stale nil ChannelID | nil-deref | no-op |

Follow-up to #550 (`(*udpConnImpl).Close` nil-deref).
