### PR TITLE
fix(discord): update to correct subscription status enum values

### DIFF
--- a/discord/subscription.go
+++ b/discord/subscription.go
@@ -23,6 +23,6 @@ type SubscriptionStatus int
 
 const (
 	SubscriptionStatusActive SubscriptionStatus = iota
-	SubscriptionStatusEnding
 	SubscriptionStatusInactive
+	SubscriptionStatusEnding
 )


### PR DESCRIPTION
Fix `SubscriptionStatus` enum values

Discord API Docs reference:
- https://github.com/discord/discord-api-docs/commit/7c81aa8bc41594fab4d56028f2726be93cad312f