### PR TITLE
Update readme to include a new library & a bot stack recently refactored to disgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ or in these projects:
 * [Kitsune-Bot](https://github.com/TopiSenpai/Kitsune-Bot)
 * [KittyBot](https://github.com/KittyBot-Org/KittyBotGo)
 * [subcordant](https://github.com/apkatsikas/subcordant)
+* [Yugen Stack](https://github.com/jurienhamaker/yugen)
 
 ## Libraries for DisGo
 


### PR DESCRIPTION
I've update the readme to include a library & bots I maintain.

I am the creator of several bots, and I recently migrated the bots to disgo (from discordgo lol). 

These are part of the "Yugen stack":
- [Kusari](https://top.gg/bot/1186650405703262208/) (~2500 guilds)
- [Koto](https://top.gg/bot/1164654805730472018/) (~1200 guilds)
- [Kazu](https://top.gg/bot/1260679337594589356/) (~200 guilds)
- [Hoshi](https://top.gg/bot/1208707348659445800/) (~200 guilds)

~~I've also maintained a small library for discordgo (called discordgoplus) that would add support for components v2 & a router that data inside the custom id's. Because the current disgo router does not seem to support that, I've written a similair library for disgo~~