### PR TITLE
feat(voice): gate audio sender on DAVE session readiness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 )
 
 require golang.org/x/sys v0.41.0 // indirect
+
+replace github.com/disgoorg/godave => ../godave

--- a/voice/audio_sender.go
+++ b/voice/audio_sender.go
@@ -99,6 +99,10 @@ func (s *defaultAudioSender) send() {
 	if s.opusProvider == nil {
 		return
 	}
+
+	if !s.conn.DaveSession().Ready() {
+		return
+	}
 	opus, err := s.opusProvider.ProvideOpusFrame()
 	if err != nil && err != io.EOF {
 		s.logger.Error("error while reading opus frame", slog.Any("err", err))

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -24,6 +24,10 @@ type (
 		// UDP returns the voice UDPConn conn used by the voice Conn.
 		UDP() UDPConn
 
+		// DaveSession returns the godave.Session used by the voice Conn to
+		// encrypt and decrypt media frames.
+		DaveSession() godave.Session
+
 		// ChannelID returns the ID of the voice channel the voice Conn is openedChan to.
 		ChannelID() *snowflake.ID
 
@@ -77,6 +81,7 @@ func NewConn(guildID snowflake.ID, userID snowflake.ID, voiceStateUpdateFunc Sta
 	}
 
 	daveSession := cfg.DaveSessionCreate(cfg.DaveSessionLogger, godave.UserID(userID.String()), conn)
+	conn.daveSession = daveSession
 	conn.gateway = cfg.GatewayCreateFunc(daveSession, conn.handleMessage, conn.handleGatewayClose, append([]GatewayConfigOpt{WithGatewayLogger(cfg.Logger)}, cfg.GatewayConfigOpts...)...)
 	conn.udp = cfg.UDPConnCreateFunc(daveSession, conn.UserIDBySSRC, append([]UDPConnConfigOpt{WithUDPConnLogger(cfg.Logger)}, cfg.UDPConnConfigOpts...)...)
 
@@ -91,8 +96,9 @@ type connImpl struct {
 	state   State
 	stateMu sync.Mutex
 
-	gateway Gateway
-	udp     UDPConn
+	gateway     Gateway
+	udp         UDPConn
+	daveSession godave.Session
 
 	audioSender   AudioSender
 	audioReceiver AudioReceiver
@@ -146,6 +152,10 @@ func (c *connImpl) SetSpeaking(ctx context.Context, flags SpeakingFlags) error {
 
 func (c *connImpl) UDP() UDPConn {
 	return c.udp
+}
+
+func (c *connImpl) DaveSession() godave.Session {
+	return c.daveSession
 }
 
 func (c *connImpl) SetOpusFrameProvider(provider OpusFrameProvider) {

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -330,7 +330,7 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State) error {
 			return nil
 		}
 
-		if errors.Is(err, discord.ErrGatewayAlreadyConnected) {
+		if errors.Is(err, ErrGatewayAlreadyConnected) {
 			return err
 		}
 


### PR DESCRIPTION
> **Draft** — depends on disgoorg/godave#<godave-pr-number>. Will update go.mod once that merges.

 When DAVE is enabled, the audio sender tries to encrypt frames immediately after joining or moving channels — before the MLS handshake completes. Every frame during that window fails with "no active epoch" and gets dropped.

This adds `DaveSession() godave.Session` to the `Conn` interface and checks `Ready()` at the top of the send loop. The sender holds off pulling frames until the epoch is established, then resumes normally. No frames are lost, playback just starts a bit later.

The noop session (non-DAVE guilds) always returns `true` so there's no behavior change there.

Related: disgoorg/disgo#555