### PR TITLE
feat: add `ChannelType` field to `EventMessageCreate` event

### DIFF
--- a/gateway/gateway_events.go
+++ b/gateway/gateway_events.go
@@ -637,6 +637,7 @@ func (EventInviteDelete) eventData()   {}
 
 type EventMessageCreate struct {
 	discord.Message
+	ChannelType *discord.ChannelType `json:"channel_type,omitempty"`
 }
 
 func (EventMessageCreate) messageData() {}


### PR DESCRIPTION
Add `ChannelType` field to `EventMessageCreate` event.

Discord API Docs reference:
- https://github.com/discord/discord-api-docs/commit/c552b8fdb4258b281c2b95be19eb7d4caf285ebb