### PR TITLE
fix: guard gateway & voice shared state against data races

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -173,13 +173,69 @@ type gatewayImpl struct {
 
 	conn            transport
 	connMu          sync.Mutex
-	heartbeatCancel context.CancelFunc
 	status          Status
 	statusMu        sync.Mutex
+	seqMu           sync.Mutex
+	heartbeatMu     sync.Mutex
+	heartbeatCancel context.CancelFunc
 
 	heartbeatInterval     time.Duration
 	lastHeartbeatSent     time.Time
 	lastHeartbeatReceived time.Time
+}
+
+func (g *gatewayImpl) setHeartbeatCancel(cancel context.CancelFunc) {
+	g.heartbeatMu.Lock()
+	g.heartbeatCancel = cancel
+	g.heartbeatMu.Unlock()
+}
+
+func (g *gatewayImpl) cancelHeartbeat() {
+	g.heartbeatMu.Lock()
+	cancel := g.heartbeatCancel
+	g.heartbeatMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (g *gatewayImpl) setLastHeartbeatSent(t time.Time) {
+	g.heartbeatMu.Lock()
+	g.lastHeartbeatSent = t
+	g.heartbeatMu.Unlock()
+}
+
+func (g *gatewayImpl) setLastHeartbeatReceived(t time.Time) {
+	g.heartbeatMu.Lock()
+	g.lastHeartbeatReceived = t
+	g.heartbeatMu.Unlock()
+}
+
+func (g *gatewayImpl) heartbeatTimes() (sent, received time.Time) {
+	g.heartbeatMu.Lock()
+	defer g.heartbeatMu.Unlock()
+	return g.lastHeartbeatSent, g.lastHeartbeatReceived
+}
+
+// setLastSequenceReceived stores a copy of seq so the stored pointer never
+// aliases the listen loop's message struct (which is mutated on the next read).
+func (g *gatewayImpl) setLastSequenceReceived(seq int) {
+	g.seqMu.Lock()
+	s := seq
+	g.config.LastSequenceReceived = &s
+	g.seqMu.Unlock()
+}
+
+func (g *gatewayImpl) clearLastSequenceReceived() {
+	g.seqMu.Lock()
+	g.config.LastSequenceReceived = nil
+	g.seqMu.Unlock()
+}
+
+func (g *gatewayImpl) getLastSequenceReceived() *int {
+	g.seqMu.Lock()
+	defer g.seqMu.Unlock()
+	return g.config.LastSequenceReceived
 }
 
 func (g *gatewayImpl) ShardID() int {
@@ -195,7 +251,7 @@ func (g *gatewayImpl) SessionID() *string {
 }
 
 func (g *gatewayImpl) LastSequenceReceived() *int {
-	return g.config.LastSequenceReceived
+	return g.getLastSequenceReceived()
 }
 
 func (g *gatewayImpl) ResumeURL() *string {
@@ -222,7 +278,7 @@ func (g *gatewayImpl) open(ctx context.Context) error {
 	g.status = StatusConnecting
 	g.statusMu.Unlock()
 
-	if g.config.LastSequenceReceived == nil || g.config.SessionID == nil {
+	if g.getLastSequenceReceived() == nil || g.config.SessionID == nil {
 		if err := g.config.IdentifyRateLimiter.Wait(ctx, g.config.ShardID); err != nil {
 			g.config.Logger.ErrorContext(ctx, "failed to wait for identify rate limiter", slog.Any("err", err))
 			g.connMu.Unlock()
@@ -246,7 +302,7 @@ func (g *gatewayImpl) open(ctx context.Context) error {
 
 	gatewayURL := wsURL + "?" + values.Encode()
 
-	g.lastHeartbeatSent = time.Now()
+	g.setLastHeartbeatSent(time.Now())
 	conn, rs, err := g.config.Dialer.DialContext(ctx, gatewayURL, nil)
 	if err != nil {
 		var body []byte
@@ -314,10 +370,8 @@ func (g *gatewayImpl) Close(ctx context.Context) {
 }
 
 func (g *gatewayImpl) CloseWithCode(ctx context.Context, code int, message string) {
-	if g.heartbeatCancel != nil {
-		g.config.Logger.DebugContext(ctx, "closing heartbeat goroutine")
-		g.heartbeatCancel()
-	}
+	g.config.Logger.DebugContext(ctx, "closing heartbeat goroutine")
+	g.cancelHeartbeat()
 
 	g.connMu.Lock()
 	defer g.connMu.Unlock()
@@ -334,7 +388,7 @@ func (g *gatewayImpl) CloseWithCode(ctx context.Context, code int, message strin
 		if code == websocket.CloseNormalClosure || code == websocket.CloseGoingAway {
 			g.config.SessionID = nil
 			g.config.ResumeURL = nil
-			g.config.LastSequenceReceived = nil
+			g.clearLastSequenceReceived()
 		}
 	}
 	g.statusMu.Lock()
@@ -379,7 +433,8 @@ func (g *gatewayImpl) sendInternal(ctx context.Context, commandType RateLimiterC
 }
 
 func (g *gatewayImpl) Latency() time.Duration {
-	return g.lastHeartbeatReceived.Sub(g.lastHeartbeatSent)
+	sent, received := g.heartbeatTimes()
+	return received.Sub(sent)
 }
 
 func (g *gatewayImpl) Presence() *MessageDataPresenceUpdate {
@@ -448,9 +503,9 @@ func (g *gatewayImpl) heartbeat() {
 	defer g.config.Logger.Debug("exiting heartbeat goroutine")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	g.heartbeatCancel = cancel
+	g.setHeartbeatCancel(cancel)
 
-	g.lastHeartbeatReceived = time.Now()
+	g.setLastHeartbeatReceived(time.Now())
 
 	// Send heartbeats periodically every `heartbeat_interval`
 	heartbeatTicker := time.NewTicker(g.heartbeatInterval)
@@ -460,8 +515,9 @@ func (g *gatewayImpl) heartbeat() {
 			return
 
 		case <-heartbeatTicker.C:
-			if g.lastHeartbeatSent.After(g.lastHeartbeatReceived) {
-				lastHeartbeatAgo := time.Since(g.lastHeartbeatReceived)
+			lastHeartbeatSent, lastHeartbeatReceived := g.heartbeatTimes()
+			if lastHeartbeatSent.After(lastHeartbeatReceived) {
+				lastHeartbeatAgo := time.Since(lastHeartbeatReceived)
 				g.config.Logger.Warn("ACK of last heartbeat not received, connection went zombie", slog.Duration("last_heartbeat_ago", lastHeartbeatAgo))
 				closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				g.CloseWithCode(closeCtx, websocket.CloseServiceRestart, "heartbeat ACK not received")
@@ -479,8 +535,8 @@ func (g *gatewayImpl) sendHeartbeat() {
 	g.config.Logger.Debug("sending heartbeat")
 
 	sequence := 0
-	if g.config.LastSequenceReceived != nil {
-		sequence = *g.config.LastSequenceReceived
+	if lastSeq := g.getLastSequenceReceived(); lastSeq != nil {
+		sequence = *lastSeq
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), g.heartbeatInterval)
@@ -496,7 +552,7 @@ func (g *gatewayImpl) sendHeartbeat() {
 		go g.reconnect()
 		return
 	}
-	g.lastHeartbeatSent = time.Now()
+	g.setLastHeartbeatSent(time.Now())
 }
 
 func (g *gatewayImpl) identify() error {
@@ -538,7 +594,7 @@ func (g *gatewayImpl) resume() error {
 	resume := MessageDataResume{
 		Token:     g.token,
 		SessionID: *g.config.SessionID,
-		Seq:       *g.config.LastSequenceReceived,
+		Seq:       *g.getLastSequenceReceived(),
 	}
 	g.config.Logger.Debug("sending Resume command")
 
@@ -582,7 +638,7 @@ func (g *gatewayImpl) listen(conn transport, ready func(error)) {
 				reconnect = closeCode.Reconnect
 
 				if closeCode == CloseEventCodeInvalidSeq {
-					g.config.LastSequenceReceived = nil
+					g.clearLastSequenceReceived()
 					g.config.SessionID = nil
 					g.config.ResumeURL = nil
 				}
@@ -626,7 +682,7 @@ func (g *gatewayImpl) listen(conn transport, ready func(error)) {
 			g.heartbeatInterval = time.Duration(message.D.(MessageDataHello).HeartbeatInterval) * time.Millisecond
 			go g.heartbeat()
 
-			if g.config.LastSequenceReceived == nil || g.config.SessionID == nil {
+			if g.getLastSequenceReceived() == nil || g.config.SessionID == nil {
 				err = g.identify()
 			} else {
 				err = g.resume()
@@ -638,7 +694,7 @@ func (g *gatewayImpl) listen(conn transport, ready func(error)) {
 
 		case OpcodeDispatch:
 			// set last sequence received
-			g.config.LastSequenceReceived = &message.S
+			g.setLastSequenceReceived(message.S)
 
 			eventData, ok := message.D.(EventData)
 			if !ok && message.D != nil {
@@ -706,7 +762,7 @@ func (g *gatewayImpl) listen(conn transport, ready func(error)) {
 			} else {
 				// clear resume info
 				g.config.SessionID = nil
-				g.config.LastSequenceReceived = nil
+				g.clearLastSequenceReceived()
 				g.config.ResumeURL = nil
 			}
 
@@ -728,9 +784,9 @@ func (g *gatewayImpl) listen(conn transport, ready func(error)) {
 
 		case OpcodeHeartbeatACK:
 			newHeartbeat := time.Now()
-			g.lastHeartbeatReceived = newHeartbeat
+			g.setLastHeartbeatReceived(newHeartbeat)
 			g.eventHandlerFunc(g, EventTypeHeartbeatAck, message.S, EventHeartbeatAck{
-				LastHeartbeat: g.lastHeartbeatReceived,
+				LastHeartbeat: newHeartbeat,
 				NewHeartbeat:  newHeartbeat,
 			})
 

--- a/voice/audio_receiver.go
+++ b/voice/audio_receiver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net"
+	"sync"
 
 	"github.com/disgoorg/snowflake/v2"
 )
@@ -52,20 +53,22 @@ func NewAudioReceiver(logger *slog.Logger, opusReceiver OpusFrameReceiver, conn 
 
 type defaultAudioReceiver struct {
 	logger       *slog.Logger
+	mu           sync.Mutex // guards cancelFunc against Open/Close on different goroutines
 	cancelFunc   context.CancelFunc
 	opusReceiver OpusFrameReceiver
 	conn         Conn
 }
 
 func (s *defaultAudioReceiver) Open() {
-	go s.open()
+	ctx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.cancelFunc = cancel
+	s.mu.Unlock()
+	go s.open(ctx)
 }
 
-func (s *defaultAudioReceiver) open() {
+func (s *defaultAudioReceiver) open(ctx context.Context) {
 	defer s.logger.Debug("closing audio receiver")
-	ctx, cancel := context.WithCancel(context.Background())
-	s.cancelFunc = cancel
-	defer cancel()
 loop:
 	for {
 		select {
@@ -99,6 +102,11 @@ func (s *defaultAudioReceiver) receive() {
 }
 
 func (s *defaultAudioReceiver) Close() {
-	s.cancelFunc()
+	s.mu.Lock()
+	cancel := s.cancelFunc
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	s.opusReceiver.Close()
 }

--- a/voice/audio_sender.go
+++ b/voice/audio_sender.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"sync"
 	"time"
 )
 
@@ -55,6 +56,7 @@ func NewAudioSender(logger *slog.Logger, opusProvider OpusFrameProvider, conn Co
 
 type defaultAudioSender struct {
 	logger       *slog.Logger
+	mu           sync.Mutex // guards cancelFunc against Open/Close on different goroutines
 	cancelFunc   context.CancelFunc
 	opusProvider OpusFrameProvider
 	conn         Conn
@@ -65,15 +67,17 @@ type defaultAudioSender struct {
 }
 
 func (s *defaultAudioSender) Open() {
-	go s.open()
+	ctx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.cancelFunc = cancel
+	s.mu.Unlock()
+	go s.open(ctx)
 }
 
-func (s *defaultAudioSender) open() {
+func (s *defaultAudioSender) open(ctx context.Context) {
 	defer s.logger.Debug("closing audio sender")
+	defer s.Close()
 	lastFrameSent := time.Now().UnixMilli()
-	ctx, cancel := context.WithCancel(context.Background())
-	s.cancelFunc = cancel
-	defer cancel()
 loop:
 	for {
 		select {
@@ -147,5 +151,10 @@ func (s *defaultAudioSender) handleErr(err error) {
 }
 
 func (s *defaultAudioSender) Close() {
-	s.cancelFunc()
+	s.mu.Lock()
+	cancel := s.cancelFunc
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -115,25 +115,105 @@ type gatewayImpl struct {
 	eventHandlerFunc EventHandlerFunc
 	closeHandlerFunc CloseHandlerFunc
 
+	seqMu sync.Mutex
 	ssrc  uint32
 	state State
 	seq   int
 
-	daveSession     godave.Session
-	conn            *websocket.Conn
-	connMu          sync.Mutex
-	heartbeatCancel context.CancelFunc
-	status          Status
-	statusMu        sync.Mutex
+	daveSession godave.Session
+	conn        *websocket.Conn
+	connMu      sync.Mutex
+	status      Status
+	statusMu    sync.Mutex
 
+	heartbeatMu           sync.Mutex
+	heartbeatCancel       context.CancelFunc
 	heartbeatInterval     time.Duration
 	lastHeartbeatSent     time.Time
 	lastHeartbeatReceived time.Time
 	lastNonce             int64
 }
 
+func (g *gatewayImpl) setHeartbeatCancel(cancel context.CancelFunc) {
+	g.heartbeatMu.Lock()
+	g.heartbeatCancel = cancel
+	g.heartbeatMu.Unlock()
+}
+
+func (g *gatewayImpl) cancelHeartbeat() {
+	g.heartbeatMu.Lock()
+	cancel := g.heartbeatCancel
+	g.heartbeatMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (g *gatewayImpl) setLastHeartbeatSent(t time.Time) {
+	g.heartbeatMu.Lock()
+	g.lastHeartbeatSent = t
+	g.heartbeatMu.Unlock()
+}
+
+func (g *gatewayImpl) setLastHeartbeatReceived(t time.Time) {
+	g.heartbeatMu.Lock()
+	g.lastHeartbeatReceived = t
+	g.heartbeatMu.Unlock()
+}
+
+func (g *gatewayImpl) heartbeatTimes() (sent, received time.Time) {
+	g.heartbeatMu.Lock()
+	defer g.heartbeatMu.Unlock()
+	return g.lastHeartbeatSent, g.lastHeartbeatReceived
+}
+
+func (g *gatewayImpl) setLastNonce(nonce int64) {
+	g.heartbeatMu.Lock()
+	g.lastNonce = nonce
+	g.heartbeatMu.Unlock()
+}
+
+func (g *gatewayImpl) getLastNonce() int64 {
+	g.heartbeatMu.Lock()
+	defer g.heartbeatMu.Unlock()
+	return g.lastNonce
+}
+
 func (g *gatewayImpl) SSRC() uint32 {
+	g.seqMu.Lock()
+	defer g.seqMu.Unlock()
 	return g.ssrc
+}
+
+func (g *gatewayImpl) setSeq(seq int) {
+	g.seqMu.Lock()
+	g.seq = seq
+	g.seqMu.Unlock()
+}
+
+func (g *gatewayImpl) getSeq() int {
+	g.seqMu.Lock()
+	defer g.seqMu.Unlock()
+	return g.seq
+}
+
+func (g *gatewayImpl) setSSRC(ssrc uint32) {
+	g.seqMu.Lock()
+	g.ssrc = ssrc
+	g.seqMu.Unlock()
+}
+
+func (g *gatewayImpl) resetSeqSSRC() {
+	g.seqMu.Lock()
+	g.ssrc = 0
+	g.seq = 0
+	g.seqMu.Unlock()
+}
+
+func (g *gatewayImpl) ssrcAndSeq() (uint32, int) {
+	g.seqMu.Lock()
+	defer g.seqMu.Unlock()
+	return g.ssrc, g.seq
 }
 
 func (g *gatewayImpl) Open(ctx context.Context, state State) error {
@@ -155,7 +235,7 @@ func (g *gatewayImpl) open(ctx context.Context, state State) error {
 	g.statusMu.Unlock()
 
 	gatewayURL := fmt.Sprintf("wss://%s?v=%d", state.Endpoint, GatewayVersion)
-	g.lastHeartbeatSent = time.Now()
+	g.setLastHeartbeatSent(time.Now())
 	conn, rs, err := g.config.Dialer.DialContext(ctx, gatewayURL, nil)
 	if err != nil {
 		var body []byte
@@ -216,10 +296,8 @@ func (g *gatewayImpl) Close() {
 }
 
 func (g *gatewayImpl) CloseWithCode(code int, message string) {
-	if g.heartbeatCancel != nil {
-		g.config.Logger.Debug("closing heartbeat goroutine")
-		g.heartbeatCancel()
-	}
+	g.config.Logger.Debug("closing heartbeat goroutine")
+	g.cancelHeartbeat()
 
 	g.connMu.Lock()
 	defer g.connMu.Unlock()
@@ -233,8 +311,7 @@ func (g *gatewayImpl) CloseWithCode(code int, message string) {
 
 		// clear resume data as we closed gracefully
 		if code == websocket.CloseNormalClosure || code == websocket.CloseGoingAway {
-			g.ssrc = 0
-			g.seq = 0
+			g.resetSeqSSRC()
 		}
 	}
 	g.statusMu.Lock()
@@ -299,7 +376,8 @@ func (g *gatewayImpl) send(ctx context.Context, messageType int, data []byte) er
 }
 
 func (g *gatewayImpl) Latency() time.Duration {
-	return g.lastHeartbeatReceived.Sub(g.lastHeartbeatSent)
+	sent, received := g.heartbeatTimes()
+	return received.Sub(sent)
 }
 
 func (g *gatewayImpl) doReconnect(ctx context.Context, state State) error {
@@ -365,9 +443,9 @@ func (g *gatewayImpl) heartbeat() {
 	defer g.config.Logger.Debug("exiting voice heartbeat goroutine")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	g.heartbeatCancel = cancel
+	g.setHeartbeatCancel(cancel)
 
-	g.lastHeartbeatReceived = time.Now()
+	g.setLastHeartbeatReceived(time.Now())
 
 	// Send heartbeats periodically every `heartbeat_interval`
 	heartbeatTicker := time.NewTicker(g.heartbeatInterval)
@@ -377,8 +455,9 @@ func (g *gatewayImpl) heartbeat() {
 			return
 
 		case <-heartbeatTicker.C:
-			if g.lastHeartbeatSent.After(g.lastHeartbeatReceived) {
-				lastHeartbeatAgo := time.Since(g.lastHeartbeatReceived)
+			lastHeartbeatSent, lastHeartbeatReceived := g.heartbeatTimes()
+			if lastHeartbeatSent.After(lastHeartbeatReceived) {
+				lastHeartbeatAgo := time.Since(lastHeartbeatReceived)
 				g.config.Logger.Warn("ACK of last heartbeat not received, connection went zombie", slog.Duration("last_heartbeat_ago", lastHeartbeatAgo))
 				g.CloseWithCode(websocket.CloseServiceRestart, "heartbeat ACK not received")
 				go g.reconnect()
@@ -393,13 +472,14 @@ func (g *gatewayImpl) heartbeat() {
 func (g *gatewayImpl) sendHeartbeat() {
 	g.config.Logger.Debug("sending heartbeat")
 
-	g.lastNonce = time.Now().UnixMilli()
+	nonce := time.Now().UnixMilli()
+	g.setLastNonce(nonce)
 	ctx, cancel := context.WithTimeout(context.Background(), g.heartbeatInterval)
 	defer cancel()
 
 	if err := g.Send(ctx, OpcodeHeartbeat, GatewayMessageDataHeartbeat{
-		T:      g.lastNonce,
-		SeqAck: g.seq,
+		T:      nonce,
+		SeqAck: g.getSeq(),
 	}); err != nil {
 		if !errors.Is(err, ErrGatewayNotConnected) || errors.Is(err, syscall.EPIPE) {
 			return
@@ -409,7 +489,7 @@ func (g *gatewayImpl) sendHeartbeat() {
 		go g.reconnect()
 		return
 	}
-	g.lastHeartbeatSent = time.Now()
+	g.setLastHeartbeatSent(time.Now())
 }
 
 func (g *gatewayImpl) identify() error {
@@ -447,7 +527,7 @@ func (g *gatewayImpl) resume() error {
 		GuildID:   g.state.GuildID,
 		SessionID: g.state.SessionID,
 		Token:     g.state.Token,
-		SeqAck:    g.seq,
+		SeqAck:    g.getSeq(),
 	}
 	g.config.Logger.Debug("sending Resume command")
 
@@ -526,7 +606,7 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 		}
 
 		if message.Seq > 0 {
-			g.seq = message.Seq
+			g.setSeq(message.Seq)
 		}
 
 		switch message.Op {
@@ -535,7 +615,7 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 			g.heartbeatInterval = time.Duration(d.HeartbeatInterval) * time.Millisecond
 			go g.heartbeat()
 
-			if g.ssrc == 0 || g.seq == 0 {
+			if ssrc, seq := g.ssrcAndSeq(); ssrc == 0 || seq == 0 {
 				err = g.identify()
 			} else {
 				err = g.resume()
@@ -550,7 +630,7 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 			g.status = StatusReady
 			g.statusMu.Unlock()
 			d := message.D.(GatewayMessageDataReady)
-			g.ssrc = d.SSRC
+			g.setSSRC(d.SSRC)
 			ready(nil)
 
 		case OpcodeResumed:
@@ -561,12 +641,12 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 
 		case OpcodeHeartbeatACK:
 			d := message.D.(GatewayMessageDataHeartbeatACK)
-			if d.T != g.lastNonce {
-				g.config.Logger.Error("received heartbeat ack with nonce", slog.Int64("nonce", d.T), slog.Int64("last_nonce", g.lastNonce))
+			if lastNonce := g.getLastNonce(); d.T != lastNonce {
+				g.config.Logger.Error("received heartbeat ack with nonce", slog.Int64("nonce", d.T), slog.Int64("last_nonce", lastNonce))
 				go g.reconnect()
 				return
 			}
-			g.lastHeartbeatReceived = time.Now()
+			g.setLastHeartbeatReceived(time.Now())
 
 		case OpcodeSessionDescription:
 			d := message.D.(GatewayMessageDataSessionDescription)


### PR DESCRIPTION
# fix: guard gateway & voice shared state against data races

## Summary

Mutable fields on `gatewayImpl` (HTTP & voice) and the audio sender/receiver were read/written from multiple goroutines (listen loop, heartbeat, and caller `Open`/`Close`/`Latency`) without synchronization. This adds mutexes and accessor helpers so all shared state is accessed safely, fixing the races flagged under `-race`.

## Changes

- **`gateway/gateway.go`** — `heartbeatMu` guards `heartbeatCancel` + heartbeat timestamps; `seqMu` guards `LastSequenceReceived`. `setLastSequenceReceived` now stores a *copy*, so the pointer no longer aliases the listen loop's message struct.
- **`voice/gateway.go`** — same heartbeat/seq guarding, plus `lastNonce`, `ssrc`, and `seq` accessors.
- **`voice/audio_sender.go` / `audio_receiver.go`** — `sync.Mutex` guards `cancelFunc`, now created in `Open()` before the goroutine starts and nil-checked in `Close()` (fixes a race + possible nil deref).

## Testing

- [x] `go test --race -cover ./...`
- [x] `go build ./...`
- [x] `golangci-lint run`
