### PR TITLE
feat: implement channel obfuscation

### DIFF
--- a/bot/handlers/channel_handler.go
+++ b/bot/handlers/channel_handler.go
@@ -37,20 +37,22 @@ func gatewayHandlerChannelUpdate(client *bot.Client, sequenceNumber int, shardID
 	})
 
 	if event.Type() == discord.ChannelTypeGuildText || event.Type() == discord.ChannelTypeGuildNews {
-		if member, ok := client.Caches.Member(event.GuildID(), client.ID()); ok &&
-			client.Caches.MemberPermissionsInChannel(event.GuildChannel, member).Missing(discord.PermissionViewChannel) {
-			for _, guildThread := range client.Caches.GuildThreadsInChannel(event.ID()) {
-				client.Caches.RemoveThreadMembersByThreadID(guildThread.ID())
-				client.Caches.RemoveChannel(guildThread.ID())
-				client.EventManager.DispatchEvent(&events.ThreadHide{
-					GenericThread: &events.GenericThread{
-						GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
-						Thread:       guildThread,
-						ThreadID:     guildThread.ID(),
-						GuildID:      guildThread.GuildID(),
-						ParentID:     *guildThread.ParentID(),
-					},
-				})
+		if !discord.ChannelFlagsOf(event.GuildChannel).Has(discord.ChannelFlagObfuscated) {
+			if member, ok := client.Caches.Member(event.GuildID(), client.ID()); ok &&
+				client.Caches.MemberPermissionsInChannel(event.GuildChannel, member).Missing(discord.PermissionViewChannel) {
+				for _, guildThread := range client.Caches.GuildThreadsInChannel(event.ID()) {
+					client.Caches.RemoveThreadMembersByThreadID(guildThread.ID())
+					client.Caches.RemoveChannel(guildThread.ID())
+					client.EventManager.DispatchEvent(&events.ThreadHide{
+						GenericThread: &events.GenericThread{
+							GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
+							Thread:       guildThread,
+							ThreadID:     guildThread.ID(),
+							GuildID:      guildThread.GuildID(),
+							ParentID:     *guildThread.ParentID(),
+						},
+					})
+				}
 			}
 		}
 	}

--- a/bot/handlers/channel_handler.go
+++ b/bot/handlers/channel_handler.go
@@ -37,22 +37,20 @@ func gatewayHandlerChannelUpdate(client *bot.Client, sequenceNumber int, shardID
 	})
 
 	if event.Type() == discord.ChannelTypeGuildText || event.Type() == discord.ChannelTypeGuildNews {
-		if !discord.ChannelFlagsOf(event.GuildChannel).Has(discord.ChannelFlagObfuscated) {
-			if member, ok := client.Caches.Member(event.GuildID(), client.ID()); ok &&
-				client.Caches.MemberPermissionsInChannel(event.GuildChannel, member).Missing(discord.PermissionViewChannel) {
-				for _, guildThread := range client.Caches.GuildThreadsInChannel(event.ID()) {
-					client.Caches.RemoveThreadMembersByThreadID(guildThread.ID())
-					client.Caches.RemoveChannel(guildThread.ID())
-					client.EventManager.DispatchEvent(&events.ThreadHide{
-						GenericThread: &events.GenericThread{
-							GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
-							Thread:       guildThread,
-							ThreadID:     guildThread.ID(),
-							GuildID:      guildThread.GuildID(),
-							ParentID:     *guildThread.ParentID(),
-						},
-					})
-				}
+		if member, ok := client.Caches.Member(event.GuildID(), client.ID()); ok &&
+			client.Caches.MemberPermissionsInChannel(event.GuildChannel, member).Missing(discord.PermissionViewChannel) {
+			for _, guildThread := range client.Caches.GuildThreadsInChannel(event.ID()) {
+				client.Caches.RemoveThreadMembersByThreadID(guildThread.ID())
+				client.Caches.RemoveChannel(guildThread.ID())
+				client.EventManager.DispatchEvent(&events.ThreadHide{
+					GenericThread: &events.GenericThread{
+						GenericEvent: events.NewGenericEvent(client, sequenceNumber, shardID),
+						Thread:       guildThread,
+						ThreadID:     guildThread.ID(),
+						GuildID:      guildThread.GuildID(),
+						ParentID:     *guildThread.ParentID(),
+					},
+				})
 			}
 		}
 	}

--- a/cache/caches.go
+++ b/cache/caches.go
@@ -976,6 +976,12 @@ func (c *cachesImpl) MemberPermissions(member discord.Member) discord.Permission
 }
 
 func (c *cachesImpl) MemberPermissionsInChannel(channel discord.GuildChannel, member discord.Member) discord.Permissions {
+	if discord.ChannelFlagsOf(channel).Has(discord.ChannelFlagObfuscated) {
+		if selfUser, ok := c.SelfUser(); ok && selfUser.ID == member.User.ID {
+			return discord.PermissionsNone
+		}
+	}
+
 	permissions := c.MemberPermissions(member)
 	if permissions.Has(discord.PermissionAdministrator) {
 		return discord.PermissionsAll

--- a/cache/caches.go
+++ b/cache/caches.go
@@ -977,9 +977,7 @@ func (c *cachesImpl) MemberPermissions(member discord.Member) discord.Permission
 
 func (c *cachesImpl) MemberPermissionsInChannel(channel discord.GuildChannel, member discord.Member) discord.Permissions {
 	if discord.ChannelFlagsOf(channel).Has(discord.ChannelFlagObfuscated) {
-		if selfUser, ok := c.SelfUser(); ok && selfUser.ID == member.User.ID {
-			return discord.PermissionsNone
-		}
+		return discord.PermissionsNone
 	}
 
 	permissions := c.MemberPermissions(member)

--- a/discord/channel.go
+++ b/discord/channel.go
@@ -42,6 +42,7 @@ const (
 	_
 	ChannelFlagRequireTag
 	ChannelFlagHideMediaDownloadOptions ChannelFlags = 1 << 15
+	ChannelFlagObfuscated               ChannelFlags = 1 << 17
 	ChannelFlagsNone                    ChannelFlags = 0
 )
 
@@ -253,6 +254,7 @@ type GuildTextChannel struct {
 	parentID                   *snowflake.ID
 	lastPinTimestamp           *time.Time
 	defaultAutoArchiveDuration AutoArchiveDuration
+	Flags                      ChannelFlags
 }
 
 func (c *GuildTextChannel) UnmarshalJSON(data []byte) error {
@@ -273,6 +275,7 @@ func (c *GuildTextChannel) UnmarshalJSON(data []byte) error {
 	c.parentID = v.ParentID
 	c.lastPinTimestamp = v.LastPinTimestamp
 	c.defaultAutoArchiveDuration = v.DefaultAutoArchiveDuration
+	c.Flags = v.Flags
 	return nil
 }
 
@@ -291,6 +294,7 @@ func (c GuildTextChannel) MarshalJSON() ([]byte, error) {
 		ParentID:                   c.parentID,
 		LastPinTimestamp:           c.lastPinTimestamp,
 		DefaultAutoArchiveDuration: c.defaultAutoArchiveDuration,
+		Flags:                      c.Flags,
 	})
 }
 
@@ -535,6 +539,7 @@ type GuildVoiceChannel struct {
 	lastMessageID        *snowflake.ID
 	nsfw                 bool
 	rateLimitPerUser     int
+	Flags                ChannelFlags
 }
 
 func (c *GuildVoiceChannel) UnmarshalJSON(data []byte) error {
@@ -556,6 +561,7 @@ func (c *GuildVoiceChannel) UnmarshalJSON(data []byte) error {
 	c.lastMessageID = v.LastMessageID
 	c.nsfw = v.NSFW
 	c.rateLimitPerUser = v.RateLimitPerUser
+	c.Flags = v.Flags
 	return nil
 }
 
@@ -575,6 +581,7 @@ func (c GuildVoiceChannel) MarshalJSON() ([]byte, error) {
 		LastMessageID:        c.lastMessageID,
 		NSFW:                 c.nsfw,
 		RateLimitPerUser:     c.rateLimitPerUser,
+		Flags:                c.Flags,
 	})
 }
 
@@ -670,6 +677,7 @@ type GuildCategoryChannel struct {
 	position             int
 	permissionOverwrites PermissionOverwrites
 	name                 string
+	Flags                ChannelFlags
 }
 
 func (c *GuildCategoryChannel) UnmarshalJSON(data []byte) error {
@@ -683,6 +691,7 @@ func (c *GuildCategoryChannel) UnmarshalJSON(data []byte) error {
 	c.position = v.Position
 	c.permissionOverwrites = v.PermissionOverwrites
 	c.name = v.Name
+	c.Flags = v.Flags
 	return nil
 }
 
@@ -694,6 +703,7 @@ func (c GuildCategoryChannel) MarshalJSON() ([]byte, error) {
 		Position:             c.position,
 		PermissionOverwrites: c.permissionOverwrites,
 		Name:                 c.name,
+		Flags:                c.Flags,
 	})
 }
 
@@ -761,6 +771,7 @@ type GuildNewsChannel struct {
 	parentID                   *snowflake.ID
 	lastPinTimestamp           *time.Time
 	defaultAutoArchiveDuration AutoArchiveDuration
+	Flags                      ChannelFlags
 }
 
 func (c *GuildNewsChannel) UnmarshalJSON(data []byte) error {
@@ -781,6 +792,7 @@ func (c *GuildNewsChannel) UnmarshalJSON(data []byte) error {
 	c.parentID = v.ParentID
 	c.lastPinTimestamp = v.LastPinTimestamp
 	c.defaultAutoArchiveDuration = v.DefaultAutoArchiveDuration
+	c.Flags = v.Flags
 	return nil
 }
 
@@ -799,6 +811,7 @@ func (c GuildNewsChannel) MarshalJSON() ([]byte, error) {
 		ParentID:                   c.parentID,
 		LastPinTimestamp:           c.lastPinTimestamp,
 		DefaultAutoArchiveDuration: c.defaultAutoArchiveDuration,
+		Flags:                      c.Flags,
 	})
 }
 
@@ -1032,6 +1045,7 @@ type GuildStageVoiceChannel struct {
 	lastMessageID        *snowflake.ID
 	nsfw                 bool
 	rateLimitPerUser     int
+	Flags                ChannelFlags
 }
 
 func (c *GuildStageVoiceChannel) UnmarshalJSON(data []byte) error {
@@ -1052,6 +1066,7 @@ func (c *GuildStageVoiceChannel) UnmarshalJSON(data []byte) error {
 	c.lastMessageID = v.LastMessageID
 	c.nsfw = v.NSFW
 	c.rateLimitPerUser = v.RateLimitPerUser
+	c.Flags = v.Flags
 	return nil
 }
 
@@ -1070,6 +1085,7 @@ func (c GuildStageVoiceChannel) MarshalJSON() ([]byte, error) {
 		LastMessageID:        c.lastMessageID,
 		NSFW:                 c.nsfw,
 		RateLimitPerUser:     c.rateLimitPerUser,
+		Flags:                c.Flags,
 	})
 }
 
@@ -1448,7 +1464,31 @@ const (
 )
 
 func channelString(channel Channel) string {
+	if guildCh, ok := channel.(GuildChannel); ok && ChannelFlagsOf(guildCh).Has(ChannelFlagObfuscated) {
+		return fmt.Sprintf("Obfuscated Channel (%d)", channel.ID())
+	}
 	return fmt.Sprintf("%d:%s(%s)", channel.Type(), channel.Name(), channel.ID())
+}
+
+func ChannelFlagsOf(channel GuildChannel) ChannelFlags {
+	switch c := channel.(type) {
+	case GuildTextChannel:
+		return c.Flags
+	case GuildVoiceChannel:
+		return c.Flags
+	case GuildCategoryChannel:
+		return c.Flags
+	case GuildNewsChannel:
+		return c.Flags
+	case GuildStageVoiceChannel:
+		return c.Flags
+	case GuildForumChannel:
+		return c.Flags
+	case GuildMediaChannel:
+		return c.Flags
+	default:
+		return ChannelFlagsNone
+	}
 }
 
 func ApplyGuildIDToThread(guildThread GuildThread, guildID snowflake.ID) GuildThread {

--- a/discord/channels_raw.go
+++ b/discord/channels_raw.go
@@ -39,6 +39,7 @@ type guildTextChannel struct {
 	ParentID                   *snowflake.ID         `json:"parent_id"`
 	LastPinTimestamp           *time.Time            `json:"last_pin_timestamp"`
 	DefaultAutoArchiveDuration AutoArchiveDuration   `json:"default_auto_archive_duration"`
+	Flags                      ChannelFlags          `json:"flags"`
 }
 
 func (t *guildTextChannel) UnmarshalJSON(data []byte) error {
@@ -69,6 +70,7 @@ type guildNewsChannel struct {
 	LastMessageID              *snowflake.ID         `json:"last_message_id"`
 	LastPinTimestamp           *time.Time            `json:"last_pin_timestamp"`
 	DefaultAutoArchiveDuration AutoArchiveDuration   `json:"default_auto_archive_duration"`
+	Flags                      ChannelFlags          `json:"flags"`
 }
 
 func (t *guildNewsChannel) UnmarshalJSON(data []byte) error {
@@ -109,6 +111,7 @@ type guildCategoryChannel struct {
 	Position             int                   `json:"position"`
 	PermissionOverwrites []PermissionOverwrite `json:"permission_overwrites"`
 	Name                 string                `json:"name"`
+	Flags                ChannelFlags          `json:"flags"`
 }
 
 func (t *guildCategoryChannel) UnmarshalJSON(data []byte) error {
@@ -140,6 +143,7 @@ type guildVoiceChannel struct {
 	LastMessageID        *snowflake.ID         `json:"last_message_id"`
 	NSFW                 bool                  `json:"nsfw"`
 	RateLimitPerUser     int                   `json:"rate_limit_per_user"`
+	Flags                ChannelFlags          `json:"flags"`
 }
 
 func (t *guildVoiceChannel) UnmarshalJSON(data []byte) error {
@@ -171,6 +175,7 @@ type guildStageVoiceChannel struct {
 	LastMessageID        *snowflake.ID         `json:"last_message_id"`
 	NSFW                 bool                  `json:"nsfw"`
 	RateLimitPerUser     int                   `json:"rate_limit_per_user"`
+	Flags                ChannelFlags          `json:"flags"`
 }
 
 func (t *guildStageVoiceChannel) UnmarshalJSON(data []byte) error {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -517,6 +517,7 @@ func (g *gatewayImpl) identify() error {
 		Intents:        g.config.Intents,
 		Presence:       g.config.Presence,
 		Shard:          &[2]int{g.ShardID(), g.ShardCount()},
+		Capabilities:   g.config.Capabilities,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/gateway/gateway_config.go
+++ b/gateway/gateway_config.go
@@ -66,6 +66,7 @@ type config struct {
 	Browser string
 	// Device is the Device it should send on login. Defaults to "disgo".
 	Device       string
+	Capabilities GatewayCapabilities
 	CloseHandler CloseHandlerFunc
 }
 
@@ -261,5 +262,13 @@ func WithDevice(device string) ConfigOpt {
 func WithCloseHandler(closeHandler CloseHandlerFunc) ConfigOpt {
 	return func(config *config) {
 		config.CloseHandler = closeHandler
+	}
+}
+
+// WithCapabilities sets the GatewayCapabilities for the Gateway.
+// See here for more information: https://discord.com/developers/docs/events/gateway-events#identify-gateway-capabilities
+func WithCapabilities(capabilities ...GatewayCapabilities) ConfigOpt {
+	return func(config *config) {
+		config.Capabilities = config.Capabilities.Add(capabilities...)
 	}
 }

--- a/gateway/gateway_messages.go
+++ b/gateway/gateway_messages.go
@@ -8,6 +8,7 @@ import (
 	"github.com/disgoorg/snowflake/v2"
 
 	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/internal/flags"
 )
 
 // Message raw Message type
@@ -543,9 +544,40 @@ type MessageDataIdentify struct {
 	Shard          *[2]int                       `json:"shard,omitempty"`
 	Intents        Intents                       `json:"intents"`
 	Presence       *MessageDataPresenceUpdate    `json:"presence,omitempty"`
+	Capabilities   GatewayCapabilities           `json:"capabilities,omitempty"`
 }
 
 func (MessageDataIdentify) messageData() {}
+
+// GatewayCapabilities is a bitfield used to opt into in-progress gateway behaviors.
+type GatewayCapabilities int
+
+const (
+	// GatewayCapabilityChannelObfuscation opts the app into receiving obfuscated channel metadata
+	// over the Gateway for channels it can't view (temporary).
+	GatewayCapabilityChannelObfuscation GatewayCapabilities = 1 << 15
+	GatewayCapabilitiesNone             GatewayCapabilities = 0
+)
+
+// Add allows you to add multiple bits together, producing a new bit
+func (c GatewayCapabilities) Add(bits ...GatewayCapabilities) GatewayCapabilities {
+	return flags.Add(c, bits...)
+}
+
+// Remove allows you to subtract multiple bits from the first, producing a new bit
+func (c GatewayCapabilities) Remove(bits ...GatewayCapabilities) GatewayCapabilities {
+	return flags.Remove(c, bits...)
+}
+
+// Has will ensure that the bit includes all the bits entered
+func (c GatewayCapabilities) Has(bits ...GatewayCapabilities) bool {
+	return flags.Has(c, bits...)
+}
+
+// Missing will check whether the bit is missing any one of the bits
+func (c GatewayCapabilities) Missing(bits ...GatewayCapabilities) bool {
+	return flags.Missing(c, bits...)
+}
 
 // IdentifyCommandDataProperties is used for specifying to discord which library and OS the bot is using, is
 // automatically handled by the library and should rarely be used.


### PR DESCRIPTION
## Summary
This PR adds support for channel obfuscation.
Official PR: https://github.com/discord/discord-api-docs/pull/8454

> [!NOTE]
> `GatewayCapabilityChannelObfuscation` is commented as "temporary", because on Nov 16th private channel obfuscation will become default for everyone and the references to the flag from the docs is [planned to be removed](https://github.com/discord/discord-api-docs/pull/8454#issuecomment-4918395980).