### PR TITLE
fix(interaction): update ResolvedChannel schema

### DIFF
--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -154,12 +154,20 @@ type ResolvedMember struct {
 func (ResolvedMember) isMentionableValue() {}
 
 type ResolvedChannel struct {
-	ID             snowflake.ID   `json:"id"`
-	Name           string         `json:"name"`
-	Type           ChannelType    `json:"type"`
-	Permissions    Permissions    `json:"permissions"`
-	ThreadMetadata ThreadMetadata `json:"thread_metadata"`
-	ParentID       snowflake.ID   `json:"parent_id"`
+	ID               snowflake.ID    `json:"id"`
+	Name             string          `json:"name"`
+	Type             ChannelType     `json:"type"`
+	Permissions      Permissions     `json:"permissions"`
+	LastMessageID    *snowflake.ID   `json:"last_message_id,omitempty"`
+	LastPinTimestamp *time.Time      `json:"last_pin_timestamp,omitempty"`
+	NSFW             bool            `json:"nsfw,omitempty"`
+	GuildID          snowflake.ID    `json:"guild_id"`
+	Flags            ChannelFlags    `json:"flags,omitempty"`
+	RateLimitPerUser int             `json:"rate_limit_per_user,omitempty"`
+	Topic            *string         `json:"topic,omitempty"`
+	Position         int             `json:"position,omitempty"`
+	ThreadMetadata   *ThreadMetadata `json:"thread_metadata,omitempty"`
+	ParentID         *snowflake.ID   `json:"parent_id,omitempty"`
 }
 
 func (ResolvedChannel) isMentionableValue() {}

--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -158,7 +158,7 @@ type ResolvedChannel struct {
 	Name             string          `json:"name"`
 	Type             ChannelType     `json:"type"`
 	Permissions      Permissions     `json:"permissions"`
- AppPermissions   Permissions     `json:"app_permissions"`
+	AppPermissions   Permissions     `json:"app_permissions"`
 	LastMessageID    *snowflake.ID   `json:"last_message_id,omitempty"`
 	LastPinTimestamp *time.Time      `json:"last_pin_timestamp,omitempty"`
 	NSFW             bool            `json:"nsfw,omitempty"`

--- a/discord/interaction.go
+++ b/discord/interaction.go
@@ -158,6 +158,7 @@ type ResolvedChannel struct {
 	Name             string          `json:"name"`
 	Type             ChannelType     `json:"type"`
 	Permissions      Permissions     `json:"permissions"`
+ AppPermissions   Permissions     `json:"app_permissions"`
 	LastMessageID    *snowflake.ID   `json:"last_message_id,omitempty"`
 	LastPinTimestamp *time.Time      `json:"last_pin_timestamp,omitempty"`
 	NSFW             bool            `json:"nsfw,omitempty"`


### PR DESCRIPTION
- https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure

> Partial Channel objects only have id, name, type, permissions, last_message_id, last_pin_timestamp, nsfw, parent_id, guild_id, flags, rate_limit_per_user, topic and position fields. Threads will also have the thread_metadata field.