### PR TITLE
Close the DAVE session when the conn is discarded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/disgoorg/disgo
 go 1.24.0
 
 require (
-	github.com/disgoorg/godave v0.2.0
+	github.com/disgoorg/godave v0.3.0
 	github.com/disgoorg/json/v2 v2.0.0
 	github.com/disgoorg/omit v1.0.0
 	github.com/disgoorg/snowflake/v2 v2.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/disgoorg/godave v0.2.0 h1:BB6cc09UXml8yP9K2TZUADyiUF0Oosg1Pfzw1vfQGAc=
-github.com/disgoorg/godave v0.2.0/go.mod h1:OreAC3hpabr39bMVA+jwOVDq1EUPXH5A0XUBiZaDI1Y=
+github.com/disgoorg/godave v0.3.0 h1:37F3ZuiMd8/EXeoCtTeE8iP2eT2nWsfEa4/ITwoKfe4=
+github.com/disgoorg/godave v0.3.0/go.mod h1:OreAC3hpabr39bMVA+jwOVDq1EUPXH5A0XUBiZaDI1Y=
 github.com/disgoorg/json/v2 v2.0.0 h1:U16yy/ARK7/aEpzjjqK1b/KaqqGHozUdeVw/DViEzQI=
 github.com/disgoorg/json/v2 v2.0.0/go.mod h1:jZTBC0nIE1WeetSEI3/Dka8g+qglb4FPVmp5I5HpEfI=
 github.com/disgoorg/omit v1.0.0 h1:y0LkVUOyUHT8ZlnhIAeOZEA22UYykeysK8bLJ0SfT78=

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -336,6 +336,7 @@ func (c *connImpl) Close(ctx context.Context) {
 
 	c.gateway.Close()
 	_ = c.udp.Close()
+	_ = c.dave.Close()
 
 	c.removeConnFunc()
 }


### PR DESCRIPTION
Closes #566.

Calls `dave.Close()` in `connImpl.Close` right after the gateway and udp teardown, so session implementations can stop their background work when the conn goes away for good.

I only put it in `Close`, not in the voice state update handler: with `tryOpenGateway` the conn can come back after a re-join, and the dave session has to survive that. `Close` is the only point where the conn is really done.