### PR TITLE
fix: preserve unpopulated guild fields in gatewayHandlerGuildUpdate

### DIFF
--- a/bot/handlers/guild_handlers.go
+++ b/bot/handlers/guild_handlers.go
@@ -109,7 +109,10 @@ func gatewayHandlerGuildCreate(client *bot.Client, sequenceNumber int, shardID i
 }
 
 func gatewayHandlerGuildUpdate(client *bot.Client, sequenceNumber int, shardID int, event gateway.EventGuildUpdate) {
-	oldGuild, _ := client.Caches.Guild(event.ID)
+	oldGuild, ok := client.Caches.Guild(event.ID)
+	if ok {
+		event.Guild.Merge(oldGuild)
+	}
 	client.Caches.AddGuild(event.Guild)
 
 	client.EventManager.DispatchEvent(&events.GuildUpdate{

--- a/discord/guild.go
+++ b/discord/guild.go
@@ -178,6 +178,22 @@ type Guild struct {
 	ApproximatePresenceCount int `json:"approximate_presence_count"`
 }
 
+// Merge Guild updates with unpopulated fields from oldGuild, as GUILD_UPDATE does not have every field populated
+func (g *Guild) Merge(oldGuild Guild) {
+	if g.MemberCount == 0 && oldGuild.MemberCount > 0 {
+		g.MemberCount = oldGuild.MemberCount
+	}
+	if g.JoinedAt.IsZero() && !oldGuild.JoinedAt.IsZero() {
+		g.JoinedAt = oldGuild.JoinedAt
+	}
+	if g.ApproximateMemberCount == 0 && oldGuild.ApproximateMemberCount > 0 {
+		g.ApproximateMemberCount = oldGuild.ApproximateMemberCount
+	}
+	if g.ApproximatePresenceCount == 0 && oldGuild.ApproximatePresenceCount > 0 {
+		g.ApproximatePresenceCount = oldGuild.ApproximatePresenceCount
+	}
+}
+
 func (g Guild) IconURL(opts ...CDNOpt) *string {
 	if g.Icon == nil {
 		return nil


### PR DESCRIPTION
hi,
ive noticed that my member count aggregate of all servers keeps decreasing as time goes on, even as the server count does not decrease. (my code: https://github.com/jckli/mangaupdates-bot/blob/master/mubot/bot.go#L156)

it seems like when a server does any sort of GUILD_UPDATE, discord does not actually send a membercount in the response, causing disgo to just set the membercount of that server to 0, until i restart the bot as GUILD_CREATE (which happens on initialization) sends disgo the membercount. https://docs.discord.com/developers/events/gateway-events#guild-update

this fix adds some merging logic which keeps the oldGuild fields that GUILD_UPDATE object doesnt keep.

cheers
<img width="1215" height="717" alt="image" src="https://github.com/user-attachments/assets/640bf79a-4272-45f0-b9cd-02b13278cf61" />
