### PR TITLE
fix(oauth2): encode permissions as bitfield in authorization url

### DIFF
--- a/oauth2/client.go
+++ b/oauth2/client.go
@@ -91,7 +91,8 @@ func (c *Client) GenerateAuthorizationURLState(params AuthorizationURLParams) (s
 	}
 
 	if params.Permissions != discord.PermissionsNone {
-		values["permissions"] = params.Permissions
+		// Permissions.String() renders display names, so the raw bitfield must be passed explicitly.
+		values["permissions"] = uint64(params.Permissions)
 	}
 	if params.GuildID != 0 {
 		values["guild_id"] = params.GuildID

--- a/oauth2/client_test.go
+++ b/oauth2/client_test.go
@@ -1,0 +1,30 @@
+package oauth2
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+)
+
+func TestClient_GenerateAuthorizationURL_Permissions(t *testing.T) {
+	client := New(1234567890, "secret")
+
+	authURL := client.GenerateAuthorizationURL(AuthorizationURLParams{
+		RedirectURI: "https://example.com/callback",
+		Scopes:      []discord.OAuth2Scope{discord.OAuth2ScopeBot},
+		Permissions: discord.PermissionSendMessages | discord.PermissionStream,
+	})
+
+	_, query, _ := strings.Cut(authURL, "?")
+	values, err := url.ParseQuery(query)
+	if err != nil {
+		t.Fatalf("unexpected error parsing query: %v", err)
+	}
+
+	expected := "2560"
+	if got := values.Get("permissions"); got != expected {
+		t.Errorf("expected %s, got %s", expected, got)
+	}
+}


### PR DESCRIPTION
### Problem

`AuthorizationURLParams.Permissions` produces a broken authorize URL.

`QueryValues.Encode` renders every value with `fmt.Sprint` (`discord/url.go:18`), which picks up `Permissions.String()` (`discord/permissions.go:189`). That returns display names, not the bitfield:

```go
values["permissions"] = params.Permissions // oauth2/client.go:94
```

```
?permissions=Send+Messages%2C+Video
```

Discord expects the raw integer, so any caller setting `Permissions` gets an invalid invite URL. `MarshalJSON` is unaffected — it already emits the numeric string; only the query-value path is wrong.

### Fix

Pass the raw bitfield explicitly so the `Stringer` is bypassed:

```go
values["permissions"] = uint64(params.Permissions)
```

```
?permissions=2560
```

Plus a regression test asserting the encoded value.