### PR TITLE
Fix voice reconnection and channel move handling

### DIFF
--- a/voice/conn.go
+++ b/voice/conn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net"
 	"sync"
 	"time"
 
@@ -76,10 +77,7 @@ func NewConn(guildID snowflake.ID, userID snowflake.ID, voiceStateUpdateFunc Sta
 		ssrcs: map[uint32]snowflake.ID{},
 	}
 
-	daveSession := cfg.DaveSessionCreate(cfg.DaveSessionLogger, godave.UserID(userID.String()), conn)
-	conn.dave = daveSession
-	conn.gateway = cfg.GatewayCreateFunc(daveSession, conn.handleMessage, conn.handleGatewayClose, append([]GatewayConfigOpt{WithGatewayLogger(cfg.Logger)}, cfg.GatewayConfigOpts...)...)
-	conn.udp = cfg.UDPConnCreateFunc(daveSession, conn.UserIDBySSRC, append([]UDPConnConfigOpt{WithUDPConnLogger(cfg.Logger)}, cfg.UDPConnConfigOpts...)...)
+	conn.initTransports()
 
 	return conn
 }
@@ -99,26 +97,56 @@ type connImpl struct {
 	audioSender   AudioSender
 	audioReceiver AudioReceiver
 
-	openedFunc context.CancelFunc
+	openedChan        chan struct{}
+	gatewayOpenCancel context.CancelFunc
+	closed            bool
+
+	voiceStateReceived  bool
+	voiceServerReceived bool
+	speakingFlags       SpeakingFlags
+	speakingSet         bool
+
+	// gatewayOpenMu serializes calls to Gateway.Open.
+	gatewayOpenMu sync.Mutex
 
 	ssrcs   map[uint32]snowflake.ID
 	ssrcsMu sync.Mutex
 }
 
+func (c *connImpl) initTransports() {
+	daveSession := c.config.DaveSessionCreate(c.config.DaveSessionLogger, godave.UserID(c.state.UserID.String()), c)
+	c.dave = daveSession
+	c.gateway = c.config.GatewayCreateFunc(daveSession, c.handleMessage, c.handleGatewayClose, append([]GatewayConfigOpt{WithGatewayLogger(c.config.Logger)}, c.config.GatewayConfigOpts...)...)
+	c.udp = c.config.UDPConnCreateFunc(daveSession, c.UserIDBySSRC, append([]UDPConnConfigOpt{WithUDPConnLogger(c.config.Logger)}, c.config.UDPConnConfigOpts...)...)
+}
+
+// resetTransportsLocked replaces the voice transport generation. stateMu must be held.
+func (c *connImpl) resetTransportsLocked() {
+	oldGateway, oldUDP, oldDAVE := c.gateway, c.udp, c.dave
+	c.initTransports()
+	oldGateway.Close()
+	_ = oldUDP.Close()
+	_ = oldDAVE.Close()
+
+	c.ssrcsMu.Lock()
+	clear(c.ssrcs)
+	c.ssrcsMu.Unlock()
+}
+
 func (c *connImpl) SendMLSKeyPackage(mlsKeyPackage []byte) error {
-	return c.gateway.Send(context.Background(), OpcodeDaveMLSKeyPackage, GatewayMessageDataDaveMLSKeyPackage(mlsKeyPackage))
+	return c.Gateway().Send(context.Background(), OpcodeDaveMLSKeyPackage, GatewayMessageDataDaveMLSKeyPackage(mlsKeyPackage))
 }
 
 func (c *connImpl) SendMLSCommitWelcome(mlsCommitWelcome []byte) error {
-	return c.gateway.Send(context.Background(), OpcodeDaveMLSCommitWelcome, GatewayMessageDataDaveMLSCommitWelcome(mlsCommitWelcome))
+	return c.Gateway().Send(context.Background(), OpcodeDaveMLSCommitWelcome, GatewayMessageDataDaveMLSCommitWelcome(mlsCommitWelcome))
 }
 
 func (c *connImpl) SendReadyForTransition(transitionID uint16) error {
-	return c.gateway.Send(context.Background(), OpcodeDaveTransitionReady, GatewayMessageDataDaveProtocolReadyForTransition{TransitionID: transitionID})
+	return c.Gateway().Send(context.Background(), OpcodeDaveTransitionReady, GatewayMessageDataDaveProtocolReadyForTransition{TransitionID: transitionID})
 }
 
 func (c *connImpl) SendInvalidCommitWelcome(transitionID uint16) error {
-	return c.gateway.Send(context.Background(), OpcodeDaveMLSInvalidCommitWelcome, GatewayMessageDataDaveInvalidCommitWelcome{TransitionID: transitionID})
+	return c.Gateway().Send(context.Background(), OpcodeDaveMLSInvalidCommitWelcome, GatewayMessageDataDaveInvalidCommitWelcome{TransitionID: transitionID})
 }
 
 func (c *connImpl) ChannelID() *snowflake.ID {
@@ -142,21 +170,32 @@ func (c *connImpl) UserIDBySSRC(ssrc uint32) snowflake.ID {
 }
 
 func (c *connImpl) Gateway() Gateway {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	return c.gateway
 }
 
 func (c *connImpl) SetSpeaking(ctx context.Context, flags SpeakingFlags) error {
-	return c.gateway.Send(ctx, OpcodeSpeaking, GatewayMessageDataSpeaking{
-		SSRC:     c.Gateway().SSRC(),
+	c.stateMu.Lock()
+	c.speakingFlags = flags
+	c.speakingSet = true
+	gateway := c.gateway
+	c.stateMu.Unlock()
+	return gateway.Send(ctx, OpcodeSpeaking, GatewayMessageDataSpeaking{
+		SSRC:     gateway.SSRC(),
 		Speaking: flags,
 	})
 }
 
 func (c *connImpl) UDP() UDPConn {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	return c.udp
 }
 
 func (c *connImpl) DAVE() godave.Session {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	return c.dave
 }
 
@@ -184,8 +223,15 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
 
+	if c.closed {
+		return
+	}
+
 	if update.ChannelID == nil {
 		c.state.ChannelID = 0
+		c.voiceStateReceived = false
+		c.voiceServerReceived = false
+		c.cancelGatewayOpenLocked()
 		if c.audioSender != nil {
 			c.audioSender.Close()
 			c.audioSender = nil
@@ -194,52 +240,101 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 			c.audioReceiver.Close()
 			c.audioReceiver = nil
 		}
-		_ = c.udp.Close()
-		c.gateway.Close()
+		c.speakingFlags = 0
+		c.speakingSet = false
+		c.resetTransportsLocked()
 	} else {
+		moved := c.state.ChannelID != 0 && c.state.ChannelID != *update.ChannelID
 		c.state.ChannelID = *update.ChannelID
+		if moved {
+			// A move needs a new voice-server handshake. Do not leave the old
+			// websocket, UDP socket, or DAVE epoch around to race the server update.
+			c.cancelGatewayOpenLocked()
+			c.resetTransportsLocked()
+		}
 	}
 	c.state.SessionID = update.SessionID
 	c.state.SelfMute = update.SelfMute
 	c.state.SelfDeaf = update.SelfDeaf
 
-	c.tryOpenGateway()
+	if update.ChannelID != nil {
+		c.voiceStateReceived = true
+		c.tryOpenGateway()
+	}
 }
 
 func (c *connImpl) HandleVoiceServerUpdate(update botgateway.EventVoiceServerUpdate) {
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
 
-	if update.GuildID != c.state.GuildID || update.Endpoint == nil {
+	if c.closed || update.GuildID != c.state.GuildID || update.Endpoint == nil {
 		return
 	}
 
 	c.state.Token = update.Token
 	c.state.Endpoint = *update.Endpoint
-
+	c.voiceServerReceived = true
 	c.tryOpenGateway()
 }
 
 func (c *connImpl) tryOpenGateway() {
-	if c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == 0 {
-		return
-	}
-	state := c.state
 	go func() {
+		c.gatewayOpenMu.Lock()
+		defer c.gatewayOpenMu.Unlock()
+
+		c.stateMu.Lock()
+		gateway := c.gateway
+		status := gateway.Status()
+		canOpen := !c.closed && c.voiceStateReceived && c.voiceServerReceived &&
+			c.state.Token != "" && c.state.Endpoint != "" && c.state.ChannelID != 0 &&
+			(status == StatusUnconnected || status == StatusDisconnected)
+		if !canOpen {
+			c.stateMu.Unlock()
+			return
+		}
+
+		state := c.state
+		c.voiceStateReceived = false
+		c.voiceServerReceived = false
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		c.gatewayOpenCancel = cancel
+		c.stateMu.Unlock()
 		defer cancel()
-		if err := c.gateway.Open(ctx, state); err != nil {
+
+		err := gateway.Open(ctx, state)
+
+		c.stateMu.Lock()
+		c.gatewayOpenCancel = nil
+		c.stateMu.Unlock()
+
+		if err != nil && !errors.Is(err, context.Canceled) {
 			c.config.Logger.Error("error opening voice gateway", slog.Any("err", err))
 		}
 	}()
 }
 
+// cancelGatewayOpenLocked cancels the in-flight open. stateMu must be held.
+func (c *connImpl) cancelGatewayOpenLocked() {
+	if c.gatewayOpenCancel != nil {
+		c.gatewayOpenCancel()
+		c.gatewayOpenCancel = nil
+	}
+}
+
 func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int, data GatewayMessageData) {
+	c.stateMu.Lock()
+	if gateway != c.gateway {
+		c.stateMu.Unlock()
+		return
+	}
+	udp := c.udp
+	c.stateMu.Unlock()
+
 	switch d := data.(type) {
 	case GatewayMessageDataReady:
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		ourAddress, ourPort, err := c.udp.Open(ctx, d.IP, d.Port, d.SSRC)
+		ourAddress, ourPort, err := udp.Open(ctx, d.IP, d.Port, d.SSRC)
 		if err != nil {
 			c.config.Logger.Error("voice: failed to open voiceudp conn", slog.Any("err", err))
 			break
@@ -251,7 +346,7 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 			break
 		}
 
-		if err = c.Gateway().Send(ctx, OpcodeSelectProtocol, GatewayMessageDataSelectProtocol{
+		if err = gateway.Send(ctx, OpcodeSelectProtocol, GatewayMessageDataSelectProtocol{
 			Protocol: ProtocolUDP,
 			Data: GatewayMessageDataSelectProtocolData{
 				Address: ourAddress,
@@ -263,27 +358,46 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 		}
 
 	case GatewayMessageDataSessionDescription:
-		if err := c.udp.SetSecretKey(d.Mode, d.SecretKey); err != nil {
+		if err := udp.SetSecretKey(d.Mode, d.SecretKey); err != nil {
 			c.config.Logger.Error("voice: failed to set secret key", slog.Any("err", err))
 		}
-		if openedFunc := c.openedFunc; openedFunc != nil {
-			openedFunc()
+
+		c.stateMu.Lock()
+		speakingFlags, speakingSet := c.speakingFlags, c.speakingSet
+		current := gateway == c.gateway
+		c.stateMu.Unlock()
+		if current && speakingSet {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := gateway.Send(ctx, OpcodeSpeaking, GatewayMessageDataSpeaking{
+				SSRC:     gateway.SSRC(),
+				Speaking: speakingFlags,
+			}); err != nil {
+				c.config.Logger.Error("voice: failed to restore speaking state", slog.Any("err", err))
+			}
+			cancel()
 		}
+
+		c.stateMu.Lock()
+		if gateway == c.gateway && c.openedChan != nil {
+			close(c.openedChan)
+			c.openedChan = nil
+		}
+		c.stateMu.Unlock()
 
 	case GatewayMessageDataSpeaking:
 		c.ssrcsMu.Lock()
-		defer c.ssrcsMu.Unlock()
 		c.ssrcs[d.SSRC] = d.UserID
+		c.ssrcsMu.Unlock()
 
 	case GatewayMessageDataClientDisconnect:
 		c.ssrcsMu.Lock()
-		defer c.ssrcsMu.Unlock()
 		for ssrc, userID := range c.ssrcs {
 			if userID == d.UserID {
 				delete(c.ssrcs, ssrc)
 				break
 			}
 		}
+		c.ssrcsMu.Unlock()
 		if c.audioReceiver != nil {
 			c.audioReceiver.CleanupUser(d.UserID)
 		}
@@ -293,15 +407,29 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 	}
 }
 
-func (c *connImpl) handleGatewayClose(_ Gateway, err error) {
+func (c *connImpl) handleGatewayClose(gateway Gateway, err error) {
+	c.stateMu.Lock()
+	if gateway != c.gateway || c.closed {
+		c.stateMu.Unlock()
+		return
+	}
+	state := c.state
+	c.stateMu.Unlock()
+
 	var closeError *websocket.CloseError
 	if errors.As(err, &closeError) {
 		closeCode := GatewayCloseEventCodeByCode(closeError.Code)
+		if closeCode == GatewayCloseEventCodeDisconnected || closeCode == GatewayCloseEventCodeCallTerminated {
+			// These closes can precede the main gateway updates that distinguish
+			// a move from a disconnect. Acting here races those definitive updates.
+			return
+		}
 		if closeCode.NewConnection {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if err = c.Open(ctx, c.state.ChannelID, c.state.SelfMute, c.state.SelfDeaf); err != nil {
+			if err = c.Open(ctx, state.ChannelID, state.SelfMute, state.SelfDeaf); err != nil {
 				c.config.Logger.Error("voice: failed to reopen voice conn after full reconnect close code", slog.Any("err", err))
+			} else {
 				return
 			}
 		}
@@ -315,16 +443,31 @@ func (c *connImpl) handleGatewayClose(_ Gateway, err error) {
 func (c *connImpl) Open(ctx context.Context, channelID snowflake.ID, selfMute bool, selfDeaf bool) error {
 	c.config.Logger.Debug("opening voice conn")
 
-	openedCtx, cancel := context.WithCancel(context.Background())
-	c.openedFunc = cancel
-	defer cancel()
+	openedChan := make(chan struct{})
+	c.stateMu.Lock()
+	if c.closed {
+		c.stateMu.Unlock()
+		return net.ErrClosed
+	}
+	c.voiceStateReceived = false
+	c.voiceServerReceived = false
+	c.openedChan = openedChan
+	guildID := c.state.GuildID
+	c.stateMu.Unlock()
+	defer func() {
+		c.stateMu.Lock()
+		if c.openedChan == openedChan {
+			c.openedChan = nil
+		}
+		c.stateMu.Unlock()
+	}()
 
-	if err := c.voiceStateUpdateFunc(ctx, c.state.GuildID, &channelID, selfMute, selfDeaf); err != nil {
+	if err := c.voiceStateUpdateFunc(ctx, guildID, &channelID, selfMute, selfDeaf); err != nil {
 		return err
 	}
 
 	select {
-	case <-openedCtx.Done():
+	case <-openedChan:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -332,11 +475,25 @@ func (c *connImpl) Open(ctx context.Context, channelID snowflake.ID, selfMute bo
 }
 
 func (c *connImpl) Close(ctx context.Context) {
-	_ = c.voiceStateUpdateFunc(ctx, c.state.GuildID, nil, false, false)
+	c.stateMu.Lock()
+	if c.closed {
+		c.stateMu.Unlock()
+		return
+	}
+	c.closed = true
+	c.state.ChannelID = 0
+	c.voiceStateReceived = false
+	c.voiceServerReceived = false
+	c.cancelGatewayOpenLocked()
+	guildID := c.state.GuildID
+	gateway, udp, dave := c.gateway, c.udp, c.dave
+	c.stateMu.Unlock()
 
-	c.gateway.Close()
-	_ = c.udp.Close()
-	_ = c.dave.Close()
+	_ = c.voiceStateUpdateFunc(ctx, guildID, nil, false, false)
+
+	gateway.Close()
+	_ = udp.Close()
+	_ = dave.Close()
 
 	c.removeConnFunc()
 }

--- a/voice/conn_test.go
+++ b/voice/conn_test.go
@@ -1,0 +1,329 @@
+package voice
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/disgoorg/godave"
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/gorilla/websocket"
+
+	"github.com/disgoorg/disgo/discord"
+	botgateway "github.com/disgoorg/disgo/gateway"
+)
+
+type testGateway struct {
+	mu          sync.Mutex
+	status      Status
+	statusCalls chan struct{}
+	opened      chan State
+	sent        chan GatewayMessageData
+}
+
+func (g *testGateway) SSRC() uint32 { return 0 }
+
+func (g *testGateway) Open(ctx context.Context, state State) error {
+	g.mu.Lock()
+	g.status = StatusReady
+	g.mu.Unlock()
+	select {
+	case g.opened <- state:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (g *testGateway) Close() {
+	g.mu.Lock()
+	g.status = StatusDisconnected
+	g.mu.Unlock()
+}
+
+func (g *testGateway) CloseWithCode(int, string) { g.Close() }
+
+func (g *testGateway) Status() Status {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	select {
+	case g.statusCalls <- struct{}{}:
+	default:
+	}
+	return g.status
+}
+
+func (g *testGateway) Send(_ context.Context, _ Opcode, data GatewayMessageData) error {
+	if g.sent != nil {
+		g.sent <- data
+	}
+	return nil
+}
+
+func (*testGateway) Latency() time.Duration { return 0 }
+
+type testDaveSession struct {
+	godave.Session
+	ready  bool
+	closed bool
+}
+
+func (s *testDaveSession) Ready() bool {
+	return s.ready
+}
+
+func (s *testDaveSession) Close() error {
+	s.ready = false
+	s.closed = true
+	return nil
+}
+
+func newTestConn(gateway Gateway) *connImpl {
+	return NewConn(1, 2, func(context.Context, snowflake.ID, *snowflake.ID, bool, bool) error {
+		return nil
+	}, func() {}, WithConnGatewayCreateFunc(func(godave.Session, EventHandlerFunc, CloseHandlerFunc, ...GatewayConfigOpt) Gateway {
+		return gateway
+	})).(*connImpl)
+}
+
+func TestHandleMessageReleasesSSRCMutexBeforeCallback(t *testing.T) {
+	done := make(chan struct{})
+	conn := &connImpl{}
+	conn.config.EventHandlerFunc = func(Gateway, Opcode, int, GatewayMessageData) {
+		conn.UserIDBySSRC(1)
+		close(done)
+	}
+
+	go conn.handleMessage(nil, OpcodeClientDisconnect, 0, GatewayMessageDataClientDisconnect{})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("event callback blocked on ssrcsMu")
+	}
+}
+
+func TestGatewayOpenWaitsForBothVoiceUpdates(t *testing.T) {
+	tests := []struct {
+		name        string
+		serverFirst bool
+	}{
+		{name: "state first"},
+		{name: "server first", serverFirst: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gateway := &testGateway{status: StatusUnconnected, statusCalls: make(chan struct{}, 1), opened: make(chan State, 1)}
+			conn := newTestConn(gateway)
+			channelID := snowflake.ID(3)
+			endpoint := "voice.example"
+			stateUpdate := botgateway.EventVoiceStateUpdate{VoiceState: discord.VoiceState{
+				GuildID: 1, UserID: 2, ChannelID: &channelID, SessionID: "session",
+			}}
+			serverUpdate := botgateway.EventVoiceServerUpdate{GuildID: 1, Endpoint: &endpoint, Token: "token"}
+
+			if test.serverFirst {
+				conn.HandleVoiceServerUpdate(serverUpdate)
+			} else {
+				conn.HandleVoiceStateUpdate(stateUpdate)
+			}
+			<-gateway.statusCalls
+			select {
+			case <-gateway.opened:
+				t.Fatal("gateway opened before both voice updates")
+			default:
+			}
+
+			if test.serverFirst {
+				conn.HandleVoiceStateUpdate(stateUpdate)
+			} else {
+				conn.HandleVoiceServerUpdate(serverUpdate)
+			}
+
+			select {
+			case state := <-gateway.opened:
+				if state.ChannelID != channelID || state.SessionID != "session" || state.Token != "token" {
+					t.Fatalf("opened with incomplete state: %+v", state)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("gateway did not open after both voice updates")
+			}
+		})
+	}
+}
+
+func TestClosePreventsQueuedGatewayOpen(t *testing.T) {
+	gateway := &testGateway{status: StatusUnconnected, statusCalls: make(chan struct{}, 1), opened: make(chan State, 1)}
+	conn := newTestConn(gateway)
+	conn.state.ChannelID = 3
+	conn.state.SessionID = "session"
+	conn.state.Token = "token"
+	conn.state.Endpoint = "voice.example"
+	conn.voiceStateReceived = true
+	conn.voiceServerReceived = true
+
+	conn.gatewayOpenMu.Lock()
+	conn.tryOpenGateway()
+	conn.Close(context.Background())
+	conn.gatewayOpenMu.Unlock()
+
+	select {
+	case <-gateway.statusCalls:
+	case <-time.After(time.Second):
+		t.Fatal("queued gateway open did not run")
+	}
+	select {
+	case <-gateway.opened:
+		t.Fatal("gateway opened after the connection was closed")
+	default:
+	}
+
+	if err := conn.Open(context.Background(), 3, false, false); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("expected net.ErrClosed, got %v", err)
+	}
+}
+
+func TestVoiceStateChangesRecreateVoiceTransports(t *testing.T) {
+	var (
+		daveSessions    []*testDaveSession
+		gatewaySessions []godave.Session
+		udpSessions     []godave.Session
+		gateways        []*testGateway
+	)
+
+	conn := NewConn(1, 2, func(context.Context, snowflake.ID, *snowflake.ID, bool, bool) error {
+		return nil
+	}, func() {},
+		WithConnDaveSessionCreateFunc(func(*slog.Logger, godave.UserID, godave.Callbacks) godave.Session {
+			session := &testDaveSession{ready: len(daveSessions) == 0}
+			daveSessions = append(daveSessions, session)
+			return session
+		}),
+		WithConnGatewayCreateFunc(func(session godave.Session, _ EventHandlerFunc, _ CloseHandlerFunc, _ ...GatewayConfigOpt) Gateway {
+			gatewaySessions = append(gatewaySessions, session)
+			gateway := &testGateway{
+				status:      StatusUnconnected,
+				statusCalls: make(chan struct{}, 1),
+				opened:      make(chan State, 1),
+				sent:        make(chan GatewayMessageData, 1),
+			}
+			gateways = append(gateways, gateway)
+			return gateway
+		}),
+		WithUDPConnCreateFunc(func(session godave.Session, lookup SsrcLookupFunc, opts ...UDPConnConfigOpt) UDPConn {
+			udpSessions = append(udpSessions, session)
+			return NewUDPConn(session, lookup, opts...)
+		}),
+	).(*connImpl)
+	conn.state.ChannelID = 3
+	conn.state.SessionID = "session"
+	if err := conn.SetSpeaking(context.Background(), SpeakingFlagMicrophone); err != nil {
+		t.Fatalf("failed to set initial speaking state: %v", err)
+	}
+	<-gateways[0].sent
+
+	channelID := snowflake.ID(4)
+	conn.HandleVoiceStateUpdate(botgateway.EventVoiceStateUpdate{VoiceState: discord.VoiceState{
+		GuildID: 1, UserID: 2, ChannelID: &channelID, SessionID: "session",
+	}})
+
+	select {
+	case <-gateways[1].statusCalls:
+	case <-time.After(time.Second):
+		t.Fatal("queued gateway open decision did not run")
+	}
+
+	if len(daveSessions) != 2 || len(gatewaySessions) != 2 || len(udpSessions) != 2 {
+		t.Fatalf("expected two transport generations, got DAVE=%d gateway=%d UDP=%d", len(daveSessions), len(gatewaySessions), len(udpSessions))
+	}
+	if !daveSessions[0].closed {
+		t.Fatal("old DAVE session was not closed")
+	}
+	if daveSessions[1].closed || daveSessions[1].Ready() {
+		t.Fatal("new DAVE session should be open and waiting for its handshake")
+	}
+	if conn.DAVE() != daveSessions[1] || gatewaySessions[1] != daveSessions[1] || udpSessions[1] != daveSessions[1] {
+		t.Fatal("new voice transports do not share the fresh DAVE session")
+	}
+
+	conn.handleMessage(gateways[1], OpcodeSessionDescription, 0, GatewayMessageDataSessionDescription{
+		Mode:      EncryptionModeAEADAES256GCMRTPSize,
+		SecretKey: make([]byte, 32),
+	})
+	select {
+	case data := <-gateways[1].sent:
+		speaking, ok := data.(GatewayMessageDataSpeaking)
+		if !ok || speaking.Speaking != SpeakingFlagMicrophone {
+			t.Fatalf("expected microphone speaking state on the new gateway, got %#v", data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("speaking state was not restored on the new gateway")
+	}
+
+	conn.HandleVoiceStateUpdate(botgateway.EventVoiceStateUpdate{VoiceState: discord.VoiceState{
+		GuildID: 1, UserID: 2, ChannelID: nil, SessionID: "session",
+	}})
+	if len(daveSessions) != 3 || len(gatewaySessions) != 3 || len(udpSessions) != 3 {
+		t.Fatalf("expected disconnect to create a third transport generation, got DAVE=%d gateway=%d UDP=%d", len(daveSessions), len(gatewaySessions), len(udpSessions))
+	}
+	if !daveSessions[1].closed {
+		t.Fatal("disconnected DAVE session was not closed")
+	}
+	if conn.DAVE() != daveSessions[2] || gatewaySessions[2] != daveSessions[2] || udpSessions[2] != daveSessions[2] {
+		t.Fatal("disconnect did not publish fresh voice transports")
+	}
+	if conn.speakingSet {
+		t.Fatal("disconnect did not clear the stale speaking state")
+	}
+
+	conn.handleGatewayClose(gateways[1], &websocket.CloseError{
+		Code: GatewayCloseEventCodeDisconnected.Code,
+		Text: GatewayCloseEventCodeDisconnected.Description,
+	})
+	if conn.closed {
+		t.Fatal("stale disconnected gateway closed the fresh connection")
+	}
+}
+
+func TestStateDrivenGatewayClosesWaitForVoiceUpdates(t *testing.T) {
+	stateUpdates := make(chan *snowflake.ID, 1)
+	removed := make(chan struct{}, 1)
+	gateway := &testGateway{status: StatusReady, statusCalls: make(chan struct{}, 1), opened: make(chan State, 1)}
+	conn := NewConn(1, 2, func(_ context.Context, _ snowflake.ID, channelID *snowflake.ID, _ bool, _ bool) error {
+		stateUpdates <- channelID
+		return nil
+	}, func() {
+		removed <- struct{}{}
+	}, WithConnGatewayCreateFunc(func(godave.Session, EventHandlerFunc, CloseHandlerFunc, ...GatewayConfigOpt) Gateway {
+		return gateway
+	})).(*connImpl)
+	conn.state.ChannelID = 3
+	conn.state.SessionID = "session"
+	conn.state.Token = "token"
+	conn.state.Endpoint = "voice.example"
+
+	for _, closeCode := range []GatewayCloseEventCode{GatewayCloseEventCodeDisconnected, GatewayCloseEventCodeCallTerminated} {
+		conn.handleGatewayClose(gateway, &websocket.CloseError{
+			Code: closeCode.Code,
+			Text: closeCode.Description,
+		})
+	}
+
+	select {
+	case channelID := <-stateUpdates:
+		t.Fatalf("state-driven close sent an unsolicited voice state update for channel %v", channelID)
+	default:
+	}
+	select {
+	case <-removed:
+		t.Fatal("state-driven close removed the connection before the voice updates arrived")
+	default:
+	}
+	if conn.closed || conn.ChannelID() == nil || *conn.ChannelID() != 3 {
+		t.Fatal("state-driven close changed the connection while waiting for voice updates")
+	}
+}

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -496,7 +496,9 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 					slog.Int("code", closeError.Code),
 					slog.String("error", closeError.Text),
 				}
-				if reconnect {
+				if closeCode == GatewayCloseEventCodeDisconnected || closeCode == GatewayCloseEventCodeCallTerminated {
+					g.config.Logger.Debug(msg, args...)
+				} else if reconnect {
 					g.config.Logger.Warn(msg, args...)
 				} else {
 					g.config.Logger.Error(msg, args...)


### PR DESCRIPTION
### Problems

- Manually moving a voice connection between channels could stop audio transmission.
- Disconnecting, reconnecting, and immediately moving could reuse an invalid voice session (`4006`).
- Stale callbacks could close or modify the new connection.
- `4014` and `4022` closures could be treated as final before receiving the corresponding main gateway events.

### Changes

- Waits for both `VoiceStateUpdate` and `VoiceServerUpdate` before opening the voice gateway, regardless of arrival order.
- Recreates the gateway, UDP, and DAVE transports when moving or disconnecting.
- Ignores events from stale transport generations.
- Restores the speaking state after the new handshake.
- Improves state and transport synchronization and serializes voice gateway opening attempts.
- Adds a test suite covering the voice connection lifecycle.

### Testing

- Tests both gateway event orderings, transport recreation, stale callbacks, and speaking-state restoration.
- `go test ./...`
- `go test -race ./voice`
- Manually validated Discord channel moves, disconnections, and reconnections.