### PR TITLE
fix(voice): close the conn when reopening after a close code fails

### DIFF
--- a/voice/conn.go
+++ b/voice/conn.go
@@ -302,6 +302,7 @@ func (c *connImpl) handleGatewayClose(_ Gateway, err error) {
 			defer cancel()
 			if err = c.Open(ctx, c.state.ChannelID, c.state.SelfMute, c.state.SelfDeaf); err != nil {
 				c.config.Logger.Error("voice: failed to reopen voice conn after full reconnect close code", slog.Any("err", err))
+			} else {
 				return
 			}
 		}


### PR DESCRIPTION
In `handleGatewayClose`, the reconnect and teardown paths are swapped.

When `Open()` succeeds, the function falls through to the `c.Close(ctx)` below
and tears down the conn it just reopened. When `Open()` fails, it returns early
and never reaches `Close()`, so the dead conn is never removed from the manager
(`removeConnFunc`), the DAVE session is never closed, and no voice state update
is sent to leave the channel.

I ran into this in production with a `4006` (session no longer valid) right
after a `1006`: the reopen failed, the conn stayed registered as alive, and the
guild's DAVE session sat in a degraded state for hours with nothing able to
recover or clean it up.

This swaps the branches so a successful reopen returns and a failed one falls
through to the full teardown.