### PR TITLE
fix(voice): wait for both voice gateway events

### DIFF
--- a/voice/conn.go
+++ b/voice/conn.go
@@ -101,6 +101,11 @@ type connImpl struct {
 
 	openedFunc context.CancelFunc
 
+	// Discord completes a voice handshake with one event from each gateway.
+	// Only open after receiving a fresh pair so old state is never reused.
+	voiceStateReceived  bool
+	voiceServerReceived bool
+
 	ssrcs   map[uint32]snowflake.ID
 	ssrcsMu sync.Mutex
 }
@@ -186,6 +191,7 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 
 	if update.ChannelID == nil {
 		c.state.ChannelID = 0
+		c.resetVoiceEventsLocked()
 		if c.audioSender != nil {
 			c.audioSender.Close()
 			c.audioSender = nil
@@ -198,6 +204,7 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 		c.gateway.Close()
 	} else {
 		c.state.ChannelID = *update.ChannelID
+		c.voiceStateReceived = true
 	}
 	c.state.SessionID = update.SessionID
 	c.state.SelfMute = update.SelfMute
@@ -216,7 +223,7 @@ func (c *connImpl) HandleVoiceServerUpdate(update botgateway.EventVoiceServerUpd
 
 	c.state.Token = update.Token
 	c.state.Endpoint = *update.Endpoint
-
+	c.voiceServerReceived = true
 	c.tryOpenGateway()
 }
 
@@ -224,7 +231,11 @@ func (c *connImpl) tryOpenGateway() {
 	if c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == 0 {
 		return
 	}
+	if !c.voiceStateReceived || !c.voiceServerReceived {
+		return
+	}
 	state := c.state
+	c.resetVoiceEventsLocked()
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -320,7 +331,12 @@ func (c *connImpl) Open(ctx context.Context, channelID snowflake.ID, selfMute bo
 	c.openedFunc = cancel
 	defer cancel()
 
-	if err := c.voiceStateUpdateFunc(ctx, c.state.GuildID, &channelID, selfMute, selfDeaf); err != nil {
+	c.stateMu.Lock()
+	c.resetVoiceEventsLocked()
+	guildID := c.state.GuildID
+	c.stateMu.Unlock()
+
+	if err := c.voiceStateUpdateFunc(ctx, guildID, &channelID, selfMute, selfDeaf); err != nil {
 		return err
 	}
 
@@ -340,4 +356,9 @@ func (c *connImpl) Close(ctx context.Context) {
 	_ = c.dave.Close()
 
 	c.removeConnFunc()
+}
+
+func (c *connImpl) resetVoiceEventsLocked() {
+	c.voiceStateReceived = false
+	c.voiceServerReceived = false
 }


### PR DESCRIPTION
Prevent reconnects from mixing stale handshake data with fresh updates by requiring a new `VoiceStateUpdate` and `VoiceServerUpdate` before opening the voice gateway. The events may arrive in either order, but both must belong to the current connection attempt. Once consumed, they are reset so they cannot trigger another connection.

Note: This bug is one of the problems I found when moving bots between voice channels; it attempted to open the gateway with the new SessionID (`VoiceStateUpdate`) using the old token and endpoint (`VoiceServerUpdate`).