### PR TITLE
perf(log): skip building debug log bodies when debug is off

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -671,7 +671,9 @@ func (g *gatewayImpl) listen(conn transport, ready func(error)) {
 			}
 
 			if unknownEvent, ok := eventData.(EventUnknown); ok {
-				g.config.Logger.Debug("unknown event received", slog.String("event", string(message.T)), slog.String("data", string(unknownEvent)))
+				if g.config.Logger.Enabled(context.Background(), slog.LevelDebug) {
+					g.config.Logger.Debug("unknown event received", slog.String("event", string(message.T)), slog.String("data", string(unknownEvent)))
+				}
 				continue
 			}
 			g.eventHandlerFunc(g, message.T, message.S, eventData)

--- a/gateway/gateway_transports.go
+++ b/gateway/gateway_transports.go
@@ -108,7 +108,9 @@ func (t *baseTransport) WriteMessage(message Message) error {
 		return err
 	}
 
-	t.logger.Debug("sending gateway message", slog.String("data", string(data)))
+	if t.logger.Enabled(context.Background(), slog.LevelDebug) {
+		t.logger.Debug("sending gateway message", slog.String("data", string(data)))
+	}
 	return t.conn.WriteMessage(websocket.TextMessage, data)
 }
 

--- a/httpserver/handler.go
+++ b/httpserver/handler.go
@@ -95,10 +95,15 @@ const (
 // HandleInteraction handles an interaction from Discord's Outgoing Webhooks. It verifies and parses the interaction and then calls the passed EventHandlerFunc.
 func HandleInteraction(verifier Verifier, publicKey PublicKey, logger *slog.Logger, handleFunc EventHandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// we only read & keep bodies around for logging if debug logging is enabled
+		debug := logger.Enabled(r.Context(), slog.LevelDebug)
+
 		if ok := VerifyRequest(verifier, r, publicKey); !ok {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			data, _ := io.ReadAll(r.Body)
-			logger.Debug("received http interaction with invalid signature", slog.String("body", string(data)))
+			if debug {
+				data, _ := io.ReadAll(r.Body)
+				logger.DebugContext(r.Context(), "received http interaction with invalid signature", slog.String("body", string(data)))
+			}
 			return
 		}
 
@@ -106,12 +111,18 @@ func HandleInteraction(verifier Verifier, publicKey PublicKey, logger *slog.Logg
 			_ = r.Body.Close()
 		}()
 
-		buff := new(bytes.Buffer)
-		rqData, _ := io.ReadAll(io.TeeReader(r.Body, buff))
-		logger.Debug("received http interaction", slog.String("body", string(rqData)))
+		rqBody := io.Reader(r.Body)
+		if debug {
+			data, err := io.ReadAll(r.Body)
+			if err != nil {
+				logger.ErrorContext(r.Context(), "error while reading interaction body", slog.Any("err", err))
+			}
+			logger.DebugContext(r.Context(), "received http interaction", slog.String("body", string(data)))
+			rqBody = bytes.NewReader(data)
+		}
 
 		var v EventInteractionCreate
-		if err := json.NewDecoder(buff).Decode(&v); err != nil {
+		if err := json.NewDecoder(rqBody).Decode(&v); err != nil {
 			logger.Error("error while decoding interaction", slog.Any("err", err))
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -182,22 +193,26 @@ func HandleInteraction(verifier Verifier, publicKey PublicKey, logger *slog.Logg
 			return
 		}
 
-		rsBody := &bytes.Buffer{}
-		multiWriter := io.MultiWriter(w, rsBody)
+		var rsBody bytes.Buffer
+		rsWriter := io.Writer(w)
+		if debug {
+			rsWriter = io.MultiWriter(w, &rsBody)
+		}
 
 		if multiPart, ok := body.(*discord.MultipartBuffer); ok {
 			w.Header().Set("Content-Type", multiPart.ContentType)
-			_, err = io.Copy(multiWriter, multiPart.Buffer)
+			_, err = io.Copy(rsWriter, multiPart.Buffer)
 		} else {
 			w.Header().Set("Content-Type", "application/json")
-			err = json.NewEncoder(multiWriter).Encode(body)
+			err = json.NewEncoder(rsWriter).Encode(body)
 		}
 		if err != nil {
 			errorChannel <- err
 			return
 		}
 
-		rsData, _ := io.ReadAll(rsBody)
-		logger.Debug("response to http interaction", slog.String("body", string(rsData)))
+		if debug {
+			logger.DebugContext(r.Context(), "response to http interaction", slog.String("body", rsBody.String()))
+		}
 	}
 }

--- a/rest/rest_client.go
+++ b/rest/rest_client.go
@@ -82,7 +82,6 @@ func (c *clientImpl) retry(endpoint *CompiledEndpoint, rqBody any, rsBody any, t
 				return fmt.Errorf("failed to marshal request body: %w", err)
 			}
 		}
-		c.config.Logger.Debug("new request", slog.String("endpoint", endpoint.URL), slog.String("body", string(rawRqBody)))
 	}
 
 	rq, err := http.NewRequest(endpoint.Endpoint.Method, c.config.URL+endpoint.URL, bytes.NewReader(rawRqBody))
@@ -102,6 +101,10 @@ func (c *clientImpl) retry(endpoint *CompiledEndpoint, rqBody any, rsBody any, t
 
 	cfg := defaultRequestConfig(rq)
 	cfg.apply(opts)
+
+	if rqBody != nil && c.config.Logger.Enabled(cfg.Ctx, slog.LevelDebug) {
+		c.config.Logger.DebugContext(cfg.Ctx, "new request", slog.String("endpoint", endpoint.URL), slog.String("body", string(rawRqBody)))
+	}
 
 	if cfg.Delay > 0 {
 		timer := time.NewTimer(cfg.Delay)
@@ -145,7 +148,9 @@ func (c *clientImpl) retry(endpoint *CompiledEndpoint, rqBody any, rsBody any, t
 		if rawRsBody, err = io.ReadAll(rs.Body); err != nil {
 			return fmt.Errorf("error reading response body in rest client: %w", err)
 		}
-		c.config.Logger.Debug("new response", slog.String("endpoint", endpoint.URL), slog.String("code", rs.Status), slog.String("body", string(rawRsBody)))
+		if c.config.Logger.Enabled(cfg.Ctx, slog.LevelDebug) {
+			c.config.Logger.DebugContext(cfg.Ctx, "new response", slog.String("endpoint", endpoint.URL), slog.String("code", rs.Status), slog.String("body", string(rawRsBody)))
+		}
 	}
 
 	switch {

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -296,7 +296,9 @@ func (g *gatewayImpl) send(ctx context.Context, messageType int, data []byte) er
 		return ErrGatewayNotConnected
 	}
 
-	g.config.Logger.DebugContext(ctx, "sending voice gateway command", slog.String("data", string(data)))
+	if g.config.Logger.Enabled(ctx, slog.LevelDebug) {
+		g.config.Logger.DebugContext(ctx, "sending voice gateway command", slog.String("data", string(data)))
+	}
 	return g.conn.WriteMessage(messageType, data)
 }
 


### PR DESCRIPTION
Debug log calls converted raw request/response bodies to strings eagerly, e.g. `slog.String("body", string(rawRqBody))` in `rest.clientImpl.retry`. `slog.String` takes an already-built string, so the whole body was copied on every request/response even when debug logging was disabled.

Worst case is sending a message with attachments: `rawRqBody` is then the whole `discord.MultipartBuffer`, so a request with a 100MB attachment allocates and copies a 100MB string that is immediately thrown away.

Guards those calls with `Logger.Enabled`, matching the pattern already used in `voice.gatewayImpl.parseMessage`. That also covers the cases where the body was read purely to log it:

- `httpserver` no longer reads the request body of an invalid-signature request unless debug is on.
- `httpserver` no longer tees the whole interaction response into a buffer unless debug is on; previously every response, including multipart ones with attachments, was copied a second time regardless of level.

Error-level calls are left as-is since they're logged unconditionally anyway.

### Not fixed here

Multipart bodies arguably shouldn't be logged as strings at all, even at debug level: the buffer is a MIME frame whose bulk is raw attachment bytes, which aren't valid UTF-8, blow up the log output, and leak user file content. Logging the content type and buffer size instead would be more useful. Left for a follow-up to keep this PR scoped.