### PR TITLE
fix(voice): recover connections with fresh sessions

### DIFF
--- a/voice/conn.go
+++ b/voice/conn.go
@@ -60,6 +60,8 @@ type (
 	}
 )
 
+const voiceReconnectTimeout = 30 * time.Second
+
 // NewConn returns a new default voice conn.
 func NewConn(guildID snowflake.ID, userID snowflake.ID, voiceStateUpdateFunc StateUpdateFunc, removeConnFunc func(), opts ...ConnConfigOpt) Conn {
 	cfg := defaultConnConfig()
@@ -221,12 +223,12 @@ func (c *connImpl) HandleVoiceServerUpdate(update botgateway.EventVoiceServerUpd
 }
 
 func (c *connImpl) tryOpenGateway() {
-	if c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == 0 {
+	if c.state.SessionID == "" || c.state.Token == "" || c.state.Endpoint == "" || c.state.ChannelID == 0 {
 		return
 	}
 	state := c.state
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), voiceReconnectTimeout)
 		defer cancel()
 		if err := c.gateway.Open(ctx, state); err != nil {
 			c.config.Logger.Error("error opening voice gateway", slog.Any("err", err))
@@ -294,18 +296,34 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 }
 
 func (c *connImpl) handleGatewayClose(_ Gateway, err error) {
+	newConnection := true
 	var closeError *websocket.CloseError
 	if errors.As(err, &closeError) {
 		closeCode := GatewayCloseEventCodeByCode(closeError.Code)
-		if closeCode.NewConnection {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err = c.Open(ctx, c.state.ChannelID, c.state.SelfMute, c.state.SelfDeaf); err != nil {
-				c.config.Logger.Error("voice: failed to reopen voice conn after full reconnect close code", slog.Any("err", err))
-			} else {
-				return
-			}
+		newConnection = closeCode.NewConnection
+	}
+
+	if newConnection {
+		c.stateMu.Lock()
+		channelID := c.state.ChannelID
+		selfMute := c.state.SelfMute
+		selfDeaf := c.state.SelfDeaf
+		c.state.SessionID = ""
+		c.state.Token = ""
+		c.state.Endpoint = ""
+		c.stateMu.Unlock()
+
+		_ = c.udp.Close()
+		if channelID == 0 {
+			return
 		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), voiceReconnectTimeout)
+		defer cancel()
+		if err = c.Open(ctx, channelID, selfMute, selfDeaf); err != nil {
+			c.config.Logger.Error("voice: failed to reopen voice conn with a fresh session", slog.Any("err", err))
+		}
+		return
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -322,8 +322,9 @@ func (c *connImpl) handleGatewayClose(_ Gateway, err error) {
 		defer cancel()
 		if err = c.Open(ctx, channelID, selfMute, selfDeaf); err != nil {
 			c.config.Logger.Error("voice: failed to reopen voice conn with a fresh session", slog.Any("err", err))
+		} else {
+			return
 		}
-		return
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/voice/conn_test.go
+++ b/voice/conn_test.go
@@ -1,0 +1,183 @@
+package voice
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/gorilla/websocket"
+
+	"github.com/disgoorg/disgo/discord"
+	botgateway "github.com/disgoorg/disgo/gateway"
+)
+
+func TestHandleGatewayCloseStartsFreshConnection(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "invalid session",
+			err:  &websocket.CloseError{Code: GatewayCloseEventCodeSessionNoLongerValid.Code},
+		},
+		{
+			name: "resume attempts exhausted",
+			err:  errors.New("voice endpoint is unavailable"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gateway := &gatewayStub{}
+			udp := &udpConnStub{}
+			var updates []*snowflake.ID
+			var stateAtUpdate State
+			var removed bool
+			var conn *connImpl
+
+			conn = &connImpl{
+				config: defaultConnConfig(),
+				state: State{
+					GuildID:   1,
+					UserID:    2,
+					ChannelID: 3,
+					SessionID: "old-session",
+					Token:     "old-token",
+					Endpoint:  "old.discord.media",
+				},
+				gateway: gateway,
+				udp:     udp,
+				voiceStateUpdateFunc: func(_ context.Context, _ snowflake.ID, channelID *snowflake.ID, _ bool, _ bool) error {
+					updates = append(updates, channelID)
+					if channelID != nil {
+						stateAtUpdate = conn.state
+						conn.openedFunc()
+					}
+					return nil
+				},
+				removeConnFunc: func() {
+					removed = true
+				},
+			}
+
+			conn.handleGatewayClose(gateway, tt.err)
+
+			if len(updates) != 1 || updates[0] == nil || *updates[0] != 3 {
+				t.Fatalf("expected one voice state update to channel 3, got %v", updates)
+			}
+			if stateAtUpdate.SessionID != "" || stateAtUpdate.Token != "" || stateAtUpdate.Endpoint != "" {
+				t.Fatalf("expected cached voice credentials to be cleared, got %+v", stateAtUpdate)
+			}
+			if gateway.closeCalls != 0 {
+				t.Errorf("expected reopened gateway to remain open, got %d close calls", gateway.closeCalls)
+			}
+			if udp.closeCalls != 1 {
+				t.Errorf("expected stale UDP connection to be closed once, got %d close calls", udp.closeCalls)
+			}
+			if removed {
+				t.Error("expected connection to remain registered")
+			}
+		})
+	}
+}
+
+func TestVoiceGatewayWaitsForFreshStateAndServerUpdates(t *testing.T) {
+	opened := make(chan State, 1)
+	conn := &connImpl{
+		config: defaultConnConfig(),
+		state: State{
+			GuildID:   1,
+			UserID:    2,
+			ChannelID: 3,
+		},
+		gateway: &gatewayStub{opened: opened},
+	}
+	endpoint := "new.discord.media"
+
+	conn.HandleVoiceServerUpdate(botgateway.EventVoiceServerUpdate{
+		GuildID:  1,
+		Token:    "new-token",
+		Endpoint: &endpoint,
+	})
+
+	select {
+	case state := <-opened:
+		t.Fatalf("gateway opened before fresh voice state update: %+v", state)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	channelID := snowflake.ID(3)
+	conn.HandleVoiceStateUpdate(botgateway.EventVoiceStateUpdate{VoiceState: discord.VoiceState{
+		GuildID:   1,
+		UserID:    2,
+		ChannelID: &channelID,
+		SessionID: "new-session",
+	}})
+
+	select {
+	case state := <-opened:
+		if state.SessionID != "new-session" || state.Token != "new-token" || state.Endpoint != endpoint {
+			t.Fatalf("gateway opened with incomplete fresh state: %+v", state)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gateway did not open after both fresh updates arrived")
+	}
+}
+
+type gatewayStub struct {
+	closeCalls int
+	opened     chan State
+}
+
+func (*gatewayStub) SSRC() uint32 { return 0 }
+
+func (g *gatewayStub) Open(_ context.Context, state State) error {
+	if g.opened != nil {
+		g.opened <- state
+	}
+	return nil
+}
+
+func (g *gatewayStub) Close() { g.closeCalls++ }
+
+func (*gatewayStub) CloseWithCode(int, string) {}
+
+func (*gatewayStub) Status() Status { return StatusDisconnected }
+
+func (*gatewayStub) Send(context.Context, Opcode, GatewayMessageData) error { return nil }
+
+func (*gatewayStub) Latency() time.Duration { return 0 }
+
+type udpConnStub struct {
+	closeCalls int
+}
+
+func (*udpConnStub) LocalAddr() net.Addr { return nil }
+
+func (*udpConnStub) RemoteAddr() net.Addr { return nil }
+
+func (*udpConnStub) SetSecretKey(EncryptionMode, []byte) error { return nil }
+
+func (*udpConnStub) SetDeadline(time.Time) error { return nil }
+
+func (*udpConnStub) SetReadDeadline(time.Time) error { return nil }
+
+func (*udpConnStub) SetWriteDeadline(time.Time) error { return nil }
+
+func (*udpConnStub) Open(context.Context, string, int, uint32) (string, int, error) {
+	return "", 0, nil
+}
+
+func (u *udpConnStub) Close() error {
+	u.closeCalls++
+	return nil
+}
+
+func (*udpConnStub) Read([]byte) (int, error) { return 0, nil }
+
+func (*udpConnStub) ReadPacket() (*Packet, error) { return nil, nil }
+
+func (*udpConnStub) Write([]byte) (int, error) { return 0, nil }

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -24,7 +24,10 @@ import (
 // GatewayVersion is the version of the voice gateway we are using.
 const GatewayVersion = 8
 
-const maximumConnectDelay = 10 * time.Second
+const (
+	maximumConnectDelay      = 10 * time.Second
+	maximumReconnectAttempts = 5
+)
 
 // ErrGatewayNotConnected is returned when the gateway is not connected and a message is attempted to be sent.
 var ErrGatewayNotConnected = fmt.Errorf("voice gateway not connected")
@@ -139,7 +142,7 @@ func (g *gatewayImpl) SSRC() uint32 {
 }
 
 func (g *gatewayImpl) Open(ctx context.Context, state State) error {
-	return g.doReconnect(ctx, state)
+	return g.doReconnect(ctx, state, 0)
 }
 
 func (g *gatewayImpl) open(ctx context.Context, state State) error {
@@ -151,6 +154,10 @@ func (g *gatewayImpl) open(ctx context.Context, state State) error {
 		return discord.ErrGatewayAlreadyConnected
 	}
 
+	if state.SessionID != g.state.SessionID {
+		g.ssrc = 0
+		g.seq = 0
+	}
 	g.state = state
 	g.statusMu.Lock()
 	g.status = StatusConnecting
@@ -306,26 +313,22 @@ func (g *gatewayImpl) Latency() time.Duration {
 	return g.lastHeartbeatReceived.Sub(g.lastHeartbeatSent)
 }
 
-func (g *gatewayImpl) doReconnect(ctx context.Context, state State) error {
-	var (
-		try              int
-		backoffIncrement int
-	)
-
-	for {
-		// Exponentially backoff up to a limit of 10s
-		delay := time.Duration(1<<backoffIncrement) * time.Second
-		if delay > maximumConnectDelay {
-			delay = maximumConnectDelay
-		} else {
-			backoffIncrement++
-		}
-
-		timer := time.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-timer.C:
+func (g *gatewayImpl) doReconnect(ctx context.Context, state State, maximumAttempts int) error {
+	for attempt := 0; ; attempt++ {
+		delay := reconnectDelay(attempt)
+		if delay > 0 {
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				return ctx.Err()
+			case <-timer.C:
+			}
 		}
 
 		err := g.open(ctx, state)
@@ -346,17 +349,32 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State) error {
 			}
 		}
 
-		g.config.Logger.Error("failed to reconnect voice gateway", slog.Any("err", err), slog.Int("try", try), slog.Duration("delay", delay))
+		g.config.Logger.Error("failed to reconnect voice gateway", slog.Any("err", err), slog.Int("attempt", attempt+1), slog.Duration("delay", delay))
 		g.statusMu.Lock()
 		g.status = StatusDisconnected
 		g.statusMu.Unlock()
 
-		try++
+		if maximumAttempts > 0 && attempt+1 >= maximumAttempts {
+			return fmt.Errorf("failed to reconnect voice gateway after %d attempts: %w", maximumAttempts, err)
+		}
 	}
 }
 
+func reconnectDelay(attempt int) time.Duration {
+	if attempt <= 0 {
+		return 0
+	}
+	// Exponentially backoff up to a limit of 10s
+	exponent := min(attempt-1, 4)
+	delay := time.Duration(1<<exponent) * time.Second
+	if delay > maximumConnectDelay {
+		return maximumConnectDelay
+	}
+	return delay
+}
+
 func (g *gatewayImpl) reconnect() {
-	if err := g.doReconnect(context.Background(), g.state); err != nil {
+	if err := g.doReconnect(context.Background(), g.state, maximumReconnectAttempts); err != nil {
 		g.config.Logger.Error("failed to reopen voice gateway", slog.Any("err", err))
 
 		g.closeHandlerFunc(g, err)
@@ -569,6 +587,7 @@ func (g *gatewayImpl) listen(conn *websocket.Conn, ready func(error)) {
 			d := message.D.(GatewayMessageDataHeartbeatACK)
 			if d.T != g.lastNonce {
 				g.config.Logger.Error("received heartbeat ack with nonce", slog.Int64("nonce", d.T), slog.Int64("last_nonce", g.lastNonce))
+				g.CloseWithCode(websocket.CloseServiceRestart, "heartbeat ACK nonce mismatch")
 				go g.reconnect()
 				return
 			}

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -320,12 +320,6 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State, maximumAttem
 			timer := time.NewTimer(delay)
 			select {
 			case <-ctx.Done():
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
 				return ctx.Err()
 			case <-timer.C:
 			}

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -314,7 +314,8 @@ func (g *gatewayImpl) Latency() time.Duration {
 }
 
 func (g *gatewayImpl) doReconnect(ctx context.Context, state State, maximumAttempts int) error {
-	for attempt := 0; ; attempt++ {
+	var err error
+	for attempt := 0; maximumAttempts <= 0 || attempt < maximumAttempts; attempt++ {
 		delay := reconnectDelay(attempt)
 		if delay > 0 {
 			timer := time.NewTimer(delay)
@@ -325,7 +326,7 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State, maximumAttem
 			}
 		}
 
-		err := g.open(ctx, state)
+		err = g.open(ctx, state)
 		if err == nil {
 			// Successfully connected, our job here is done
 			return nil
@@ -347,11 +348,8 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State, maximumAttem
 		g.statusMu.Lock()
 		g.status = StatusDisconnected
 		g.statusMu.Unlock()
-
-		if maximumAttempts > 0 && attempt+1 >= maximumAttempts {
-			return fmt.Errorf("failed to reconnect voice gateway after %d attempts: %w", maximumAttempts, err)
-		}
 	}
+	return fmt.Errorf("failed to reconnect voice gateway after %d attempts: %w", maximumAttempts, err)
 }
 
 func reconnectDelay(attempt int) time.Duration {
@@ -359,10 +357,12 @@ func reconnectDelay(attempt int) time.Duration {
 		return 0
 	}
 	// Exponentially backoff up to a limit of 10s
-	exponent := min(attempt-1, 4)
-	delay := time.Duration(1<<exponent) * time.Second
-	if delay > maximumConnectDelay {
-		return maximumConnectDelay
+	delay := time.Second
+	for range attempt - 1 {
+		if delay > maximumConnectDelay/2 {
+			return maximumConnectDelay
+		}
+		delay *= 2
 	}
 	return delay
 }

--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -315,8 +315,14 @@ func (g *gatewayImpl) Latency() time.Duration {
 
 func (g *gatewayImpl) doReconnect(ctx context.Context, state State, maximumAttempts int) error {
 	var err error
-	for attempt := 0; maximumAttempts <= 0 || attempt < maximumAttempts; attempt++ {
-		delay := reconnectDelay(attempt)
+	attempt := 0
+	delay := time.Duration(0)
+	for {
+		if maximumAttempts > 0 && attempt >= maximumAttempts {
+			return fmt.Errorf("failed to reconnect voice gateway after %d attempts: %w", maximumAttempts, err)
+		}
+		attempt++
+
 		if delay > 0 {
 			timer := time.NewTimer(delay)
 			select {
@@ -344,27 +350,20 @@ func (g *gatewayImpl) doReconnect(ctx context.Context, state State, maximumAttem
 			}
 		}
 
-		g.config.Logger.Error("failed to reconnect voice gateway", slog.Any("err", err), slog.Int("attempt", attempt+1), slog.Duration("delay", delay))
+		g.config.Logger.Error("failed to reconnect voice gateway", slog.Any("err", err), slog.Int("attempt", attempt), slog.Duration("delay", delay))
 		g.statusMu.Lock()
 		g.status = StatusDisconnected
 		g.statusMu.Unlock()
+
+		delay = nextReconnectDelay(delay)
 	}
-	return fmt.Errorf("failed to reconnect voice gateway after %d attempts: %w", maximumAttempts, err)
 }
 
-func reconnectDelay(attempt int) time.Duration {
-	if attempt <= 0 {
-		return 0
+func nextReconnectDelay(delay time.Duration) time.Duration {
+	if delay == 0 {
+		return time.Second
 	}
-	// Exponentially backoff up to a limit of 10s
-	delay := time.Second
-	for range attempt - 1 {
-		if delay > maximumConnectDelay/2 {
-			return maximumConnectDelay
-		}
-		delay *= 2
-	}
-	return delay
+	return min(delay*2, maximumConnectDelay)
 }
 
 func (g *gatewayImpl) reconnect() {

--- a/voice/gateway_opcodes.go
+++ b/voice/gateway_opcodes.go
@@ -195,7 +195,7 @@ var (
 		Description:   "Disconnected: Rate Limited",
 		Explanation:   "Disconnect due to rate limit exceeded. Should not reconnect.",
 		Reconnect:     false,
-		NewConnection: true,
+		NewConnection: false,
 	}
 
 	GatewayCloseEventCodeCallTerminated = GatewayCloseEventCode{
@@ -203,7 +203,7 @@ var (
 		Description:   "Disconnected: Call Terminated",
 		Explanation:   "Disconnect all clients due to call terminated (channel deleted, voice server changed, etc.). Should not reconnect.",
 		Reconnect:     false,
-		NewConnection: true,
+		NewConnection: false,
 	}
 
 	GatewayCloseEventCodeUnknown = GatewayCloseEventCode{

--- a/voice/gateway_test.go
+++ b/voice/gateway_test.go
@@ -1,0 +1,39 @@
+package voice
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReconnectDelay(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{attempt: 0, want: 0},
+		{attempt: 1, want: time.Second},
+		{attempt: 2, want: 2 * time.Second},
+		{attempt: 3, want: 4 * time.Second},
+		{attempt: 4, want: 8 * time.Second},
+		{attempt: 5, want: maximumConnectDelay},
+		{attempt: 100, want: maximumConnectDelay},
+	}
+
+	for _, tt := range tests {
+		if got := reconnectDelay(tt.attempt); got != tt.want {
+			t.Errorf("reconnectDelay(%d) = %v, want %v", tt.attempt, got, tt.want)
+		}
+	}
+}
+
+func TestNonReconnectableCloseCodesDoNotStartNewConnection(t *testing.T) {
+	for _, closeCode := range []GatewayCloseEventCode{
+		GatewayCloseEventCodeDisconnected,
+		GatewayCloseEventCodeRateLimited,
+		GatewayCloseEventCodeCallTerminated,
+	} {
+		if closeCode.Reconnect || closeCode.NewConnection {
+			t.Errorf("close code %d must not reconnect: %+v", closeCode.Code, closeCode)
+		}
+	}
+}

--- a/voice/gateway_test.go
+++ b/voice/gateway_test.go
@@ -5,23 +5,22 @@ import (
 	"time"
 )
 
-func TestReconnectDelay(t *testing.T) {
+func TestNextReconnectDelay(t *testing.T) {
 	tests := []struct {
-		attempt int
-		want    time.Duration
+		delay time.Duration
+		want  time.Duration
 	}{
-		{attempt: 0, want: 0},
-		{attempt: 1, want: time.Second},
-		{attempt: 2, want: 2 * time.Second},
-		{attempt: 3, want: 4 * time.Second},
-		{attempt: 4, want: 8 * time.Second},
-		{attempt: 5, want: maximumConnectDelay},
-		{attempt: 100, want: maximumConnectDelay},
+		{delay: 0, want: time.Second},
+		{delay: time.Second, want: 2 * time.Second},
+		{delay: 2 * time.Second, want: 4 * time.Second},
+		{delay: 4 * time.Second, want: 8 * time.Second},
+		{delay: 8 * time.Second, want: maximumConnectDelay},
+		{delay: maximumConnectDelay, want: maximumConnectDelay},
 	}
 
 	for _, tt := range tests {
-		if got := reconnectDelay(tt.attempt); got != tt.want {
-			t.Errorf("reconnectDelay(%d) = %v, want %v", tt.attempt, got, tt.want)
+		if got := nextReconnectDelay(tt.delay); got != tt.want {
+			t.Errorf("nextReconnectDelay(%v) = %v, want %v", tt.delay, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Limit Voice Gateway resume attempts and use a capped exponential backoff.
- Request a fresh voice session when resuming the existing session is no longer possible.
- Wait for both fresh Voice State and Voice Server updates before opening the Voice Gateway.
- Do not reconnect after rate-limited or terminated-call close events.

## Problem

When a Voice Gateway endpoint became unavailable, the reconnect loop kept retrying the cached endpoint indefinitely. The previous delay calculation also multiplied the attempt count by an already increasing delay, allowing the interval to grow beyond the documented 10-second limit.

If those attempts eventually failed, the connection could not recover by requesting new voice credentials. This left the connection registered but unable to send speaking updates until the process was restarted.

The connection could also open as soon as a Voice Server Update supplied a token and endpoint, without waiting for the matching fresh session ID from a Voice State Update.

## Changes

- Retry Voice Gateway resume up to five times with delays capped at 10 seconds.
- Close a Voice Gateway with a mismatched heartbeat ACK before reconnecting it.
- Treat exhausted resume attempts and close codes requiring a new connection as reasons to:
  - clear the cached session ID, token, and endpoint;
  - close the stale UDP connection;
  - send a new Voice State Update; and
  - reconnect only after fresh state and server updates are both available.
- Reset voice sequencing state when switching to a new session.
- Correct close codes `4021` and `4022` so they do not start a new connection, matching Discord's documented behavior.

## Testing

- Added coverage for capped reconnect delays.
- Added coverage for close events that must not reconnect.
- Added coverage for requesting a fresh connection after an invalid session or exhausted resume attempts.
- Added coverage ensuring the Voice Gateway waits for both fresh update events.
- Ran `go test -race ./voice`.
- Ran `go test ./...`.
- Ran `go vet ./...`.