### PR TITLE
fix(voice): prevent gateway lock order deadlock

### DIFF
--- a/voice/gateway.go
+++ b/voice/gateway.go
@@ -252,15 +252,31 @@ func (g *gatewayImpl) Status() Status {
 
 func (g *gatewayImpl) Send(ctx context.Context, op Opcode, d GatewayMessageData) error {
 	g.statusMu.Lock()
+	ready := g.status == StatusReady
+	g.statusMu.Unlock()
+	if !ready {
+		return discord.ErrShardNotReady
+	}
+
+	g.connMu.Lock()
+	defer g.connMu.Unlock()
+
+	g.statusMu.Lock()
 	defer g.statusMu.Unlock()
 	if g.status != StatusReady {
 		return discord.ErrShardNotReady
 	}
 
-	return g.sendInternal(ctx, op, d)
+	return g.sendInternalLocked(ctx, op, d)
 }
 
 func (g *gatewayImpl) sendInternal(ctx context.Context, op Opcode, d GatewayMessageData) error {
+	g.connMu.Lock()
+	defer g.connMu.Unlock()
+	return g.sendInternalLocked(ctx, op, d)
+}
+
+func (g *gatewayImpl) sendInternalLocked(ctx context.Context, op Opcode, d GatewayMessageData) error {
 	if op.IsBinary() {
 		// We are basically writing the following struct here:
 		// {
@@ -276,7 +292,7 @@ func (g *gatewayImpl) sendInternal(ctx context.Context, op Opcode, d GatewayMess
 			return err
 		}
 
-		return g.send(ctx, websocket.BinaryMessage, buf.Bytes())
+		return g.sendLocked(ctx, websocket.BinaryMessage, buf.Bytes())
 	}
 
 	data, err := json.Marshal(GatewayMessage{
@@ -286,12 +302,10 @@ func (g *gatewayImpl) sendInternal(ctx context.Context, op Opcode, d GatewayMess
 	if err != nil {
 		return err
 	}
-	return g.send(ctx, websocket.TextMessage, data)
+	return g.sendLocked(ctx, websocket.TextMessage, data)
 }
 
-func (g *gatewayImpl) send(ctx context.Context, messageType int, data []byte) error {
-	g.connMu.Lock()
-	defer g.connMu.Unlock()
+func (g *gatewayImpl) sendLocked(ctx context.Context, messageType int, data []byte) error {
 	if g.conn == nil {
 		return ErrGatewayNotConnected
 	}

--- a/voice/gateway_test.go
+++ b/voice/gateway_test.go
@@ -1,0 +1,49 @@
+package voice
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSendDoesNotBlockStatusWhileWaitingForConnection(t *testing.T) {
+	gateway := &gatewayImpl{status: StatusReady}
+	gateway.connMu.Lock()
+
+	sendStarted := make(chan struct{})
+	sendDone := make(chan error, 1)
+	go func() {
+		close(sendStarted)
+		sendDone <- gateway.Send(context.Background(), OpcodeHeartbeat, GatewayMessageDataHeartbeat{})
+	}()
+	<-sendStarted
+
+	// Give Send time to reach the connection lock held by this test.
+	time.Sleep(10 * time.Millisecond)
+
+	statusDone := make(chan Status, 1)
+	go func() {
+		statusDone <- gateway.Status()
+	}()
+
+	statusBlocked := false
+	select {
+	case status := <-statusDone:
+		if status != StatusReady {
+			t.Errorf("unexpected gateway status: %v", status)
+		}
+	case <-time.After(100 * time.Millisecond):
+		statusBlocked = true
+	}
+
+	gateway.connMu.Unlock()
+
+	if err := <-sendDone; !errors.Is(err, ErrGatewayNotConnected) {
+		t.Errorf("expected ErrGatewayNotConnected, got %v", err)
+	}
+	if statusBlocked {
+		<-statusDone
+		t.Fatal("Status was blocked by Send while Send was waiting for the connection lock")
+	}
+}


### PR DESCRIPTION
## Summary

- Use a consistent mutex acquisition order for voice gateway connection and status state.
- Avoid holding the status mutex while waiting for the connection mutex.
- Add regression coverage ensuring status reads remain responsive while a send waits for the connection lock.

## Problem

`gatewayImpl.Send` held `statusMu` and then attempted to acquire `connMu`. Other gateway paths, including connection opening and closing, acquire `connMu` before `statusMu`.

When these paths ran concurrently, they could form a lock-order cycle: a send waited for the connection mutex while holding the status mutex, and a connection lifecycle operation waited for the status mutex while holding the connection mutex. This could permanently block voice gateway operations.

## Changes

- Check whether the gateway is ready without retaining `statusMu` while waiting for `connMu`.
- Acquire `connMu` before rechecking gateway readiness under `statusMu`, matching the order used by connection lifecycle paths.
- Split the internal send helpers into locking and lock-held variants so all writes remain serialized without recursively acquiring `connMu`.
- Add `TestSendDoesNotBlockStatusWhileWaitingForConnection` to cover the lock-order regression.

## Testing

- `go test -race ./voice`
- `go test ./...`
- `go vet ./...`