### PR TITLE
chore: satisfy gofumpt on master

### DIFF
--- a/discord/access_token.go
+++ b/discord/access_token.go
@@ -46,7 +46,7 @@ func (e AccessTokenResponse) MarshalJSON() ([]byte, error) {
 	}{
 		ExpiresIn:           int(e.ExpiresIn.Seconds()),
 		Scope:               JoinScopes(e.Scope),
-		accessTokenResponse: (accessTokenResponse)(e),
+		accessTokenResponse: accessTokenResponse(e),
 	})
 }
 

--- a/discord/activity.go
+++ b/discord/activity.go
@@ -67,7 +67,7 @@ func (a Activity) MarshalJSON() ([]byte, error) {
 		activity
 	}{
 		CreatedAt: a.CreatedAt.UnixMilli(),
-		activity:  (activity)(a),
+		activity:  activity(a),
 	})
 }
 

--- a/gateway/gateway_events.go
+++ b/gateway/gateway_events.go
@@ -207,7 +207,7 @@ func (c ChannelInfo) MarshalJSON() ([]byte, error) {
 		channelInfo
 	}{
 		VoiceStartTime: voiceStartTime,
-		channelInfo:    (channelInfo)(c),
+		channelInfo:    channelInfo(c),
 	})
 }
 
@@ -888,7 +888,7 @@ func (e EventVoiceChannelStartTimeUpdate) MarshalJSON() ([]byte, error) {
 		eventVoiceChannelStartTimeUpdate
 	}{
 		VoiceStartTime:                   voiceStartTime,
-		eventVoiceChannelStartTimeUpdate: (eventVoiceChannelStartTimeUpdate)(e),
+		eventVoiceChannelStartTimeUpdate: eventVoiceChannelStartTimeUpdate(e),
 	})
 }
 

--- a/voice/udp_conn.go
+++ b/voice/udp_conn.go
@@ -50,11 +50,11 @@ const (
 var ErrDecryptionFailed = errors.New("decryption failed")
 
 var (
-	_ io.Reader      = (UDPConn)(nil)
-	_ io.ReadCloser  = (UDPConn)(nil)
-	_ io.Writer      = (UDPConn)(nil)
-	_ io.WriteCloser = (UDPConn)(nil)
-	_ net.Conn       = (UDPConn)(nil)
+	_ io.Reader      = UDPConn(nil)
+	_ io.ReadCloser  = UDPConn(nil)
+	_ io.Writer      = UDPConn(nil)
+	_ io.WriteCloser = UDPConn(nil)
+	_ net.Conn       = UDPConn(nil)
 )
 
 type (


### PR DESCRIPTION
`golangci-lint run` currently fails on `master`, so every pull request opened against it inherits a red check that has nothing to do with the change.

golangci-lint 2.13.1 bundles a gofumpt that removes redundant parentheses around a conversion's type — `(T)(x)` becomes `T(x)`. Four linted files carry the older form:

- `discord/access_token.go`
- `discord/activity.go`
- `gateway/gateway_events.go`
- `voice/udp_conn.go`

Formatting only — no behaviour, no exported surface, no test changes. `go build ./...` and `go test ./...` unchanged.

`_examples` is left alone: the lint configuration excludes it, and including it would make the diff several times larger than the thing it fixes.

Noticed while #596's check went red. That PR touches `voice/udp_conn.go`, so whichever of the two merges second will need a trivial rebase — happy to sequence them whichever way suits you, or to fold this into #596 if you would rather not carry a separate formatting commit.