### PR TITLE
Fix 2 issues flagged across 2 files

### DIFF
--- a/_examples/application_commands/http/go.mod
+++ b/_examples/application_commands/http/go.mod
@@ -14,6 +14,6 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/sasha-s/go-csync v0.0.0-20240107134140-fcbab37b09ad // indirect
-	golang.org/x/crypto v0.46.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/klauspost/compress v1.19.0
 	github.com/sasha-s/go-csync v0.0.0-20240107134140-fcbab37b09ad
-	golang.org/x/crypto v0.48.0
+	golang.org/x/crypto v0.52.0
 )
 
 require golang.org/x/sys v0.41.0 // indirect


### PR DESCRIPTION
A scan flagged a few things in this repository. This changes 2 files — one item each, described below.

**1. `go.mod`, around line 1**

The library golang.org/x/crypto before v0.52.0 mishandles SSH authentication callbacks that return PartialSuccessError with non‑nil Permissions. The permissions (e.g., forced command restrictions) are silently dropped, allowing an attacker who bypasses the first authentication factor to gain a session without the intended constraints. This can lead to privilege escalation or unauthorized command execution. The vulnerability is rated HIGH due to its potential impact on confidential systems and the ease of exploitation via crafted SSH auth flows.

Updates golang.org/x/crypto to version v0.52.0, fixing all reported high‑severity CVEs.

For reference: rule `CVE-2026-39828`. Rated high.

**2. `_examples/application_commands/http/go.mod`, around line 1**

The project pins golang.org/x/crypto at v0.46.0, which contains a critical bug (CVE‑2026‑39828). When an SSH server authentication callback returns PartialSuccessError with non‑nil Permissions, the library silently drops those Permissions, allowing an attacker to bypass enforced restrictions (e.g., forced commands) after a secondary factor succeeds. This can lead to unauthorized command execution or privilege escalation. The vulnerability is classified as HIGH severity. Updating to a version where the bug is fixed (>= v0.52.0) eliminates the issue.

Update golang.org/x/crypto from v0.46.0 to v0.52.0 to address multiple high‑severity CVEs.

For reference: rule `CVE-2026-39828`. Rated high.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
