### PR TITLE
fix(voice): keep audio alive across channel moves

### DIFF
--- a/voice/conn.go
+++ b/voice/conn.go
@@ -377,6 +377,10 @@ func (c *connImpl) handleGatewayClose(gateway Gateway, err error) {
 	var closeError *websocket.CloseError
 	if errors.As(err, &closeError) {
 		closeCode := GatewayCloseEventCodeByCode(closeError.Code)
+		// Wait for `ServerUpdate` and `StateUpdate` to close the gateway (a channel move could trigger this handler)
+		if closeCode == GatewayCloseEventCodeDisconnected || closeCode == GatewayCloseEventCodeCallTerminated {
+			return
+		}
 		newConnection = closeCode.NewConnection
 	}
 

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -78,12 +78,29 @@ func NewConn(guildID snowflake.ID, userID snowflake.ID, voiceStateUpdateFunc Sta
 		ssrcs: map[uint32]snowflake.ID{},
 	}
 
-	daveSession := cfg.DaveSessionCreate(cfg.DaveSessionLogger, godave.UserID(userID.String()), conn)
-	conn.dave = daveSession
-	conn.gateway = cfg.GatewayCreateFunc(daveSession, conn.handleMessage, conn.handleGatewayClose, append([]GatewayConfigOpt{WithGatewayLogger(cfg.Logger)}, cfg.GatewayConfigOpts...)...)
-	conn.udp = cfg.UDPConnCreateFunc(daveSession, conn.UserIDBySSRC, append([]UDPConnConfigOpt{WithUDPConnLogger(cfg.Logger)}, cfg.UDPConnConfigOpts...)...)
+	conn.initTransports()
 
 	return conn
+}
+
+func (c *connImpl) initTransports() {
+	daveSession := c.config.DaveSessionCreate(c.config.DaveSessionLogger, godave.UserID(c.state.UserID.String()), c)
+	c.dave = daveSession
+	c.gateway = c.config.GatewayCreateFunc(daveSession, c.handleMessage, c.handleGatewayClose, append([]GatewayConfigOpt{WithGatewayLogger(c.config.Logger)}, c.config.GatewayConfigOpts...)...)
+	c.udp = c.config.UDPConnCreateFunc(daveSession, c.UserIDBySSRC, append([]UDPConnConfigOpt{WithUDPConnLogger(c.config.Logger)}, c.config.UDPConnConfigOpts...)...)
+}
+
+// resetTransportsLocked replaces the voice transport generation. stateMu must be held.
+func (c *connImpl) resetTransportsLocked() {
+	oldGateway, oldUDP, oldDAVE := c.gateway, c.udp, c.dave
+	c.initTransports()
+	oldGateway.Close()
+	_ = oldUDP.Close()
+	_ = oldDAVE.Close()
+
+	c.ssrcsMu.Lock()
+	clear(c.ssrcs)
+	c.ssrcsMu.Unlock()
 }
 
 type connImpl struct {
@@ -107,6 +124,9 @@ type connImpl struct {
 	// Only open after receiving a fresh pair so old state is never reused.
 	voiceStateReceived  bool
 	voiceServerReceived bool
+
+	speakingFlags SpeakingFlags
+	speakingSet   bool
 
 	ssrcs   map[uint32]snowflake.ID
 	ssrcsMu sync.Mutex
@@ -149,21 +169,32 @@ func (c *connImpl) UserIDBySSRC(ssrc uint32) snowflake.ID {
 }
 
 func (c *connImpl) Gateway() Gateway {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	return c.gateway
 }
 
 func (c *connImpl) SetSpeaking(ctx context.Context, flags SpeakingFlags) error {
-	return c.gateway.Send(ctx, OpcodeSpeaking, GatewayMessageDataSpeaking{
-		SSRC:     c.Gateway().SSRC(),
+	c.stateMu.Lock()
+	c.speakingFlags = flags
+	c.speakingSet = true
+	gateway := c.gateway
+	c.stateMu.Unlock()
+	return gateway.Send(ctx, OpcodeSpeaking, GatewayMessageDataSpeaking{
+		SSRC:     gateway.SSRC(),
 		Speaking: flags,
 	})
 }
 
 func (c *connImpl) UDP() UDPConn {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	return c.udp
 }
 
 func (c *connImpl) DAVE() godave.Session {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	return c.dave
 }
 
@@ -202,10 +233,16 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 			c.audioReceiver.Close()
 			c.audioReceiver = nil
 		}
-		_ = c.udp.Close()
-		c.gateway.Close()
+		c.speakingFlags = 0
+		c.speakingSet = false
+		c.resetTransportsLocked()
 	} else {
+		moved := c.state.ChannelID != 0 && c.state.ChannelID != *update.ChannelID
 		c.state.ChannelID = *update.ChannelID
+		if moved {
+			// A move needs a new voice-server handshake
+			c.resetTransportsLocked()
+		}
 		c.voiceStateReceived = true
 	}
 	c.state.SessionID = update.SessionID
@@ -248,11 +285,19 @@ func (c *connImpl) tryOpenGateway() {
 }
 
 func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int, data GatewayMessageData) {
+	c.stateMu.Lock()
+	if gateway != c.gateway {
+		c.stateMu.Unlock()
+		return
+	}
+	udp := c.udp
+	c.stateMu.Unlock()
+
 	switch d := data.(type) {
 	case GatewayMessageDataReady:
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		ourAddress, ourPort, err := c.udp.Open(ctx, d.IP, d.Port, d.SSRC)
+		ourAddress, ourPort, err := udp.Open(ctx, d.IP, d.Port, d.SSRC)
 		if err != nil {
 			c.config.Logger.Error("voice: failed to open voiceudp conn", slog.Any("err", err))
 			break
@@ -264,7 +309,7 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 			break
 		}
 
-		if err = c.Gateway().Send(ctx, OpcodeSelectProtocol, GatewayMessageDataSelectProtocol{
+		if err = gateway.Send(ctx, OpcodeSelectProtocol, GatewayMessageDataSelectProtocol{
 			Protocol: ProtocolUDP,
 			Data: GatewayMessageDataSelectProtocolData{
 				Address: ourAddress,
@@ -276,8 +321,22 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 		}
 
 	case GatewayMessageDataSessionDescription:
-		if err := c.udp.SetSecretKey(d.Mode, d.SecretKey); err != nil {
+		if err := udp.SetSecretKey(d.Mode, d.SecretKey); err != nil {
 			c.config.Logger.Error("voice: failed to set secret key", slog.Any("err", err))
+		}
+		c.stateMu.Lock()
+		speakingFlags, speakingSet := c.speakingFlags, c.speakingSet
+		current := gateway == c.gateway
+		c.stateMu.Unlock()
+		if current && speakingSet {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := gateway.Send(ctx, OpcodeSpeaking, GatewayMessageDataSpeaking{
+				SSRC:     gateway.SSRC(),
+				Speaking: speakingFlags,
+			}); err != nil {
+				c.config.Logger.Error("voice: failed to restore speaking state", slog.Any("err", err))
+			}
+			cancel()
 		}
 		if openedFunc := c.openedFunc; openedFunc != nil {
 			openedFunc()
@@ -306,7 +365,14 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 	}
 }
 
-func (c *connImpl) handleGatewayClose(_ Gateway, err error) {
+func (c *connImpl) handleGatewayClose(gateway Gateway, err error) {
+	c.stateMu.Lock()
+	if gateway != c.gateway {
+		c.stateMu.Unlock()
+		return
+	}
+	c.stateMu.Unlock()
+
 	newConnection := true
 	var closeError *websocket.CloseError
 	if errors.As(err, &closeError) {
@@ -324,7 +390,8 @@ func (c *connImpl) handleGatewayClose(_ Gateway, err error) {
 		c.state.Endpoint = ""
 		c.stateMu.Unlock()
 
-		_ = c.udp.Close()
+		udp := c.UDP()
+		_ = udp.Close()
 		if channelID == 0 {
 			return
 		}


### PR DESCRIPTION
When a bot is moved from one channel to another, it often disconnects, and sometimes it simply remains silent (waiting for the DAVE session to be ready). These problems are solved with these two changes:

**Rebuild voice transports when moving between channels and ignore stale callbacks**
A channel move was reusing the old Gateway/UDP/DAVE generation and stale SSRC entries carried over from the old channel, so a late Ready/SessionDescription or speaking event could revive the old epoch and drop the new handshake. On moved VoiceStateUpdate the generation is now replaced via resetTransportsLocked() under stateMu and callbacks from previous gateways are dropped. SpeakingFlags are saved in SetSpeaking and restored after SessionDescription.

**Wait for the fresh VoiceStateUpdate + VoiceServerUpdate pair instead of closing immediately on 4014/4022**
A move can surface as a gateway close. The same thing I make in the PR https://github.com/disgoorg/disgo/pull/583, only without the massive fallback. I'm uploading it here because it's necessary for the complete fix to work; otherwise, the gateway ends up closing in many cases.