### PR TITLE
fix(voice): start audio loops once the udp conn can back them

### DIFF
--- a/voice/audio_receiver.go
+++ b/voice/audio_receiver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net"
+	"sync"
 
 	"github.com/disgoorg/snowflake/v2"
 )
@@ -52,20 +53,26 @@ func NewAudioReceiver(logger *slog.Logger, opusReceiver OpusFrameReceiver, conn 
 
 type defaultAudioReceiver struct {
 	logger       *slog.Logger
-	cancelFunc   context.CancelFunc
 	opusReceiver OpusFrameReceiver
 	conn         Conn
+
+	// Open and Close reach this from different goroutines: the voice gateway
+	// starts a loop registered before Conn.Open, and the caller closes it.
+	mu         sync.Mutex
+	cancelFunc context.CancelFunc
 }
 
 func (s *defaultAudioReceiver) Open() {
-	go s.open()
-}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-func (s *defaultAudioReceiver) open() {
-	defer s.logger.Debug("closing audio receiver")
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancelFunc = cancel
-	defer cancel()
+	go s.open(ctx)
+}
+
+func (s *defaultAudioReceiver) open(ctx context.Context) {
+	defer s.logger.Debug("closing audio receiver")
 loop:
 	for {
 		select {
@@ -104,6 +111,12 @@ func (s *defaultAudioReceiver) receive() {
 }
 
 func (s *defaultAudioReceiver) Close() {
-	s.cancelFunc()
+	s.mu.Lock()
+	cancel := s.cancelFunc
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
 	s.opusReceiver.Close()
 }

--- a/voice/audio_sender.go
+++ b/voice/audio_sender.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"sync"
 	"time"
 )
 
@@ -55,9 +56,13 @@ func NewAudioSender(logger *slog.Logger, opusProvider OpusFrameProvider, conn Co
 
 type defaultAudioSender struct {
 	logger       *slog.Logger
-	cancelFunc   context.CancelFunc
 	opusProvider OpusFrameProvider
 	conn         Conn
+
+	// Open and Close reach this from different goroutines: the voice gateway
+	// starts a loop registered before Conn.Open, and the caller closes it.
+	mu         sync.Mutex
+	cancelFunc context.CancelFunc
 
 	silentFrames      int
 	sentSpeakingStop  bool
@@ -65,15 +70,17 @@ type defaultAudioSender struct {
 }
 
 func (s *defaultAudioSender) Open() {
-	go s.open()
-}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-func (s *defaultAudioSender) open() {
-	defer s.logger.Debug("closing audio sender")
-	lastFrameSent := time.Now().UnixMilli()
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancelFunc = cancel
-	defer cancel()
+	go s.open(ctx)
+}
+
+func (s *defaultAudioSender) open(ctx context.Context) {
+	defer s.logger.Debug("closing audio sender")
+	lastFrameSent := time.Now().UnixMilli()
 loop:
 	for {
 		select {
@@ -152,5 +159,11 @@ func (s *defaultAudioSender) handleErr(err error) {
 }
 
 func (s *defaultAudioSender) Close() {
-	s.cancelFunc()
+	s.mu.Lock()
+	cancel := s.cancelFunc
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
 }

--- a/voice/conn.go
+++ b/voice/conn.go
@@ -100,6 +100,11 @@ type connImpl struct {
 
 	audioSender   AudioSender
 	audioReceiver AudioReceiver
+	// audio loops can only start once the udp conn is open (ready event) and
+	// its secret key is set (session description); the setters may run earlier.
+	udpOpened    bool
+	secretKeySet bool
+	audioMu      sync.Mutex
 
 	openedFunc context.CancelFunc
 
@@ -168,19 +173,76 @@ func (c *connImpl) DAVE() godave.Session {
 }
 
 func (c *connImpl) SetOpusFrameProvider(provider OpusFrameProvider) {
-	if c.audioSender != nil {
-		c.audioSender.Close()
+	sender := c.config.AudioSenderCreateFunc(c.config.Logger, provider, c)
+
+	c.audioMu.Lock()
+	old := c.audioSender
+	c.audioSender = sender
+	start := c.udpOpened && c.secretKeySet
+	c.audioMu.Unlock()
+
+	if old != nil {
+		old.Close()
 	}
-	c.audioSender = c.config.AudioSenderCreateFunc(c.config.Logger, provider, c)
-	c.audioSender.Open()
+	if start {
+		sender.Open()
+	}
 }
 
 func (c *connImpl) SetOpusFrameReceiver(handler OpusFrameReceiver) {
-	if c.audioReceiver != nil {
-		c.audioReceiver.Close()
+	receiver := c.config.AudioReceiverCreateFunc(c.config.Logger, handler, c)
+
+	c.audioMu.Lock()
+	old := c.audioReceiver
+	c.audioReceiver = receiver
+	start := c.udpOpened && c.secretKeySet
+	c.audioMu.Unlock()
+
+	if old != nil {
+		old.Close()
 	}
-	c.audioReceiver = c.config.AudioReceiverCreateFunc(c.config.Logger, handler, c)
-	c.audioReceiver.Open()
+	if start {
+		receiver.Open()
+	}
+}
+
+// startAudioOn sets flag and starts the audio loops once both flags hold.
+// Open runs outside audioMu because the implementations are user-provided.
+func (c *connImpl) startAudioOn(flag *bool) {
+	c.audioMu.Lock()
+	if *flag {
+		c.audioMu.Unlock()
+		return
+	}
+	*flag = true
+	sender, receiver := c.audioSender, c.audioReceiver
+	start := c.udpOpened && c.secretKeySet
+	c.audioMu.Unlock()
+
+	if !start {
+		return
+	}
+	if sender != nil {
+		sender.Open()
+	}
+	if receiver != nil {
+		receiver.Open()
+	}
+}
+
+func (c *connImpl) closeAudio() {
+	c.audioMu.Lock()
+	sender, receiver := c.audioSender, c.audioReceiver
+	c.audioSender, c.audioReceiver = nil, nil
+	c.udpOpened, c.secretKeySet = false, false
+	c.audioMu.Unlock()
+
+	if sender != nil {
+		sender.Close()
+	}
+	if receiver != nil {
+		receiver.Close()
+	}
 }
 
 func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdate) {
@@ -194,14 +256,7 @@ func (c *connImpl) HandleVoiceStateUpdate(update botgateway.EventVoiceStateUpdat
 	if update.ChannelID == nil {
 		c.state.ChannelID = 0
 		c.resetVoiceEventsLocked()
-		if c.audioSender != nil {
-			c.audioSender.Close()
-			c.audioSender = nil
-		}
-		if c.audioReceiver != nil {
-			c.audioReceiver.Close()
-			c.audioReceiver = nil
-		}
+		c.closeAudio()
 		_ = c.udp.Close()
 		c.gateway.Close()
 	} else {
@@ -257,6 +312,7 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 			c.config.Logger.Error("voice: failed to open voiceudp conn", slog.Any("err", err))
 			break
 		}
+		c.startAudioOn(&c.udpOpened)
 
 		encryptionMode, err := ChooseEncryptionMode(d.Modes)
 		if err != nil {
@@ -278,6 +334,8 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 	case GatewayMessageDataSessionDescription:
 		if err := c.udp.SetSecretKey(d.Mode, d.SecretKey); err != nil {
 			c.config.Logger.Error("voice: failed to set secret key", slog.Any("err", err))
+		} else {
+			c.startAudioOn(&c.secretKeySet)
 		}
 		if openedFunc := c.openedFunc; openedFunc != nil {
 			openedFunc()
@@ -297,8 +355,11 @@ func (c *connImpl) handleMessage(gateway Gateway, op Opcode, sequenceNumber int,
 			}
 		}
 		c.ssrcsMu.Unlock()
-		if c.audioReceiver != nil {
-			c.audioReceiver.CleanupUser(d.UserID)
+		c.audioMu.Lock()
+		receiver := c.audioReceiver
+		c.audioMu.Unlock()
+		if receiver != nil {
+			receiver.CleanupUser(d.UserID)
 		}
 	}
 	if c.config.EventHandlerFunc != nil {

--- a/voice/conn_test.go
+++ b/voice/conn_test.go
@@ -3,7 +3,9 @@ package voice
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -152,14 +154,25 @@ func (*gatewayStub) Send(context.Context, Opcode, GatewayMessageData) error { re
 func (*gatewayStub) Latency() time.Duration { return 0 }
 
 type udpConnStub struct {
-	closeCalls int
+	closeCalls   int
+	opened       bool
+	openErr      error
+	packet       *Packet
+	secretKeySet bool
+	secretKeyErr error
 }
 
 func (*udpConnStub) LocalAddr() net.Addr { return nil }
 
 func (*udpConnStub) RemoteAddr() net.Addr { return nil }
 
-func (*udpConnStub) SetSecretKey(EncryptionMode, []byte) error { return nil }
+func (u *udpConnStub) SetSecretKey(EncryptionMode, []byte) error {
+	if u.secretKeyErr != nil {
+		return u.secretKeyErr
+	}
+	u.secretKeySet = true
+	return nil
+}
 
 func (*udpConnStub) SetDeadline(time.Time) error { return nil }
 
@@ -167,9 +180,17 @@ func (*udpConnStub) SetReadDeadline(time.Time) error { return nil }
 
 func (*udpConnStub) SetWriteDeadline(time.Time) error { return nil }
 
-func (*udpConnStub) Open(context.Context, string, int, uint32) (string, int, error) {
+func (u *udpConnStub) Open(context.Context, string, int, uint32) (string, int, error) {
+	if u.openErr != nil {
+		u.opened = false
+		return "", 0, u.openErr
+	}
+	u.opened = true
 	return "", 0, nil
 }
+
+// usable reports whether the socket is dialed and the encrypter built.
+func (u *udpConnStub) usable() bool { return u.opened && u.secretKeySet }
 
 func (u *udpConnStub) Close() error {
 	u.closeCalls++
@@ -178,6 +199,580 @@ func (u *udpConnStub) Close() error {
 
 func (*udpConnStub) Read([]byte) (int, error) { return 0, nil }
 
-func (*udpConnStub) ReadPacket() (*Packet, error) { return nil, nil }
+func (u *udpConnStub) ReadPacket() (*Packet, error) { return u.packet, nil }
 
 func (*udpConnStub) Write([]byte) (int, error) { return 0, nil }
+
+// SetOpusFrameProvider and SetOpusFrameReceiver may run before Conn.Open. The
+// UDP socket is dialed on the gateway's ready event and its encrypter built
+// from the session description, so a loop started by the setter has neither.
+func TestAudioLoopsWaitForUDPConn(t *testing.T) {
+	conn, udp, rec := newAudioConn()
+
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	assertLoopsOpened(t, "before any gateway message", rec, 0)
+
+	conn.handleMessage(conn.gateway, OpcodeHello, 0, GatewayMessageDataHello{})
+	assertLoopsOpened(t, "after hello", rec, 0)
+
+	gatewayReady(conn)
+	if !udp.opened {
+		t.Fatal("ready did not open the udp conn")
+	}
+	assertLoopsOpened(t, "after ready, before the secret key", rec, 0)
+
+	sessionDescription(conn)
+	assertLoopsOpened(t, "after session description", rec, 1)
+}
+
+// The session description alone does not mean the socket exists.
+func TestAudioLoopsWaitForReady(t *testing.T) {
+	conn, _, rec := newAudioConn()
+
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	sessionDescription(conn)
+
+	assertLoopsOpened(t, "after a session description with no ready", rec, 0)
+}
+
+// A failed dial leaves the conn nil, so ready arriving is not enough either.
+// Both orderings matter: the key may already be installed when the dial fails.
+func TestAudioLoopsWaitForSuccessfulDial(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyFirst bool
+	}{
+		{name: "ready first"},
+		{name: "session description first", keyFirst: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, udp, rec := newAudioConn()
+			udp.openErr = errors.New("dial failed")
+
+			conn.SetOpusFrameProvider(nopProvider{})
+			conn.SetOpusFrameReceiver(nopReceiver{})
+			if tt.keyFirst {
+				sessionDescription(conn)
+				gatewayReady(conn)
+			} else {
+				gatewayReady(conn)
+				sessionDescription(conn)
+			}
+
+			assertLoopsOpened(t, "after a failed dial", rec, 0)
+		})
+	}
+}
+
+// A failed SetSecretKey leaves the encrypter nil.
+func TestAudioLoopsWaitForSecretKey(t *testing.T) {
+	conn, udp, rec := newAudioConn()
+	udp.secretKeyErr = errors.New("unknown encryption mode")
+
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	gatewayReady(conn)
+	sessionDescription(conn)
+
+	assertLoopsOpened(t, "after a failed secret key", rec, 0)
+}
+
+// Repeated ready and session-description events must not restart running loops.
+func TestDuplicateGatewayEventsDoNotRestartAudioLoops(t *testing.T) {
+	conn, _, rec := newAudioConn()
+
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	gatewayReady(conn)
+	sessionDescription(conn)
+	gatewayReady(conn)
+	sessionDescription(conn)
+
+	assertLoopsOpened(t, "after duplicate gateway events", rec, 1)
+}
+
+// A loop registered after the conn is usable must start at once.
+func TestAudioLoopsStartWhenConnIsReady(t *testing.T) {
+	conn, _, rec := newAudioConn()
+
+	gatewayReady(conn)
+	sessionDescription(conn)
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+
+	assertLoopsOpened(t, "registered after the conn was usable", rec, 1)
+}
+
+// Playback bots register only a provider and recorders only a receiver.
+func TestAudioLoopStartsWithoutItsSibling(t *testing.T) {
+	t.Run("provider only", func(t *testing.T) {
+		conn, _, rec := newAudioConn()
+
+		conn.SetOpusFrameProvider(nopProvider{})
+		gatewayReady(conn)
+		sessionDescription(conn)
+
+		if rec.senderOpens != 1 || rec.receiverOpens != 0 {
+			t.Errorf("open calls: sender=%d receiver=%d, want 1 and 0", rec.senderOpens, rec.receiverOpens)
+		}
+	})
+
+	t.Run("receiver only", func(t *testing.T) {
+		conn, _, rec := newAudioConn()
+
+		conn.SetOpusFrameReceiver(nopReceiver{})
+		gatewayReady(conn)
+		sessionDescription(conn)
+
+		if rec.receiverOpens != 1 || rec.senderOpens != 0 {
+			t.Errorf("open calls: sender=%d receiver=%d, want 0 and 1", rec.senderOpens, rec.receiverOpens)
+		}
+	})
+}
+
+// Setters called after leaving the channel must not start loops.
+func TestAudioLoopsDoNotStartAfterChannelLeave(t *testing.T) {
+	conn, _, rec := newAudioConn()
+
+	gatewayReady(conn)
+	sessionDescription(conn)
+	leaveChannel(conn)
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+
+	assertLoopsOpened(t, "after leaving the channel", rec, 0)
+}
+
+// Leaving drops the loops, so rejoining must not revive them.
+func TestRejoinDoesNotReopenDroppedAudioLoops(t *testing.T) {
+	conn, _, rec := newAudioConn()
+
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	gatewayReady(conn)
+	sessionDescription(conn)
+	leaveChannel(conn)
+	gatewayReady(conn)
+	sessionDescription(conn)
+
+	assertLoopsOpened(t, "after leaving and handshaking again", rec, 1)
+}
+
+// A gateway close re-handshakes on the same conn without tearing down the
+// loops, so the re-handshake must not open them a second time either.
+func TestAudioLoopsSurviveGatewayClose(t *testing.T) {
+	conn, _, rec := newAudioConn()
+
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	gatewayReady(conn)
+	sessionDescription(conn)
+	conn.handleGatewayClose(conn.gateway, &websocket.CloseError{Code: GatewayCloseEventCodeSessionNoLongerValid.Code})
+
+	if conn.state.SessionID != "" {
+		t.Fatal("the gateway close returned before starting a fresh connection")
+	}
+	if rec.senderCloses != 0 || rec.receiverCloses != 0 {
+		t.Errorf("close calls after a gateway close: sender=%d receiver=%d, want 0 and 0", rec.senderCloses, rec.receiverCloses)
+	}
+
+	gatewayReady(conn)
+	sessionDescription(conn)
+	assertLoopsOpened(t, "after a gateway close and re-handshake", rec, 1)
+}
+
+// Re-arming a precondition must not reopen a loop that is still registered:
+// Open would overwrite its cancel func and leave the first goroutine running.
+func TestReconnectDoesNotReopenRunningAudioLoops(t *testing.T) {
+	t.Run("failed then successful re-dial", func(t *testing.T) {
+		conn, udp, rec := newAudioConn()
+
+		conn.SetOpusFrameProvider(nopProvider{})
+		conn.SetOpusFrameReceiver(nopReceiver{})
+		gatewayReady(conn)
+		sessionDescription(conn)
+
+		udp.openErr = errors.New("dial failed")
+		gatewayReady(conn)
+		udp.openErr = nil
+		gatewayReady(conn)
+
+		assertLoopsOpened(t, "after a failed then successful re-dial", rec, 1)
+	})
+
+	t.Run("close then handshake", func(t *testing.T) {
+		conn, _, rec := newAudioConn()
+
+		conn.SetOpusFrameProvider(nopProvider{})
+		conn.SetOpusFrameReceiver(nopReceiver{})
+		gatewayReady(conn)
+		sessionDescription(conn)
+
+		conn.Close(context.Background())
+		gatewayReady(conn)
+		sessionDescription(conn)
+
+		assertLoopsOpened(t, "after closing then handshaking again", rec, 1)
+	})
+}
+
+// A dropped loop must be closed whether or not it ever started, and the
+// replacement must be the instance that ends up running.
+func TestDroppedAudioLoopIsClosed(t *testing.T) {
+	tests := []struct {
+		name  string
+		ready bool
+		seq   []string
+	}{
+		{
+			name:  "started",
+			ready: true,
+			seq:   []string{"sender.open", "receiver.open", "sender.close", "sender.open", "receiver.close", "receiver.open"},
+		},
+		{
+			name: "unstarted",
+			seq:  []string{"sender.close", "receiver.close"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, _, rec := newAudioConn()
+			if tt.ready {
+				gatewayReady(conn)
+				sessionDescription(conn)
+			}
+
+			conn.SetOpusFrameProvider(nopProvider{})
+			conn.SetOpusFrameReceiver(nopReceiver{})
+			conn.SetOpusFrameProvider(nopProvider{})
+			conn.SetOpusFrameReceiver(nopReceiver{})
+
+			if rec.senderCloses != 1 || rec.receiverCloses != 1 {
+				t.Errorf("close calls: sender=%d receiver=%d, want 1 and 1", rec.senderCloses, rec.receiverCloses)
+			}
+			if !slices.Equal(rec.seq, tt.seq) {
+				t.Errorf("call sequence = %v, want %v", rec.seq, tt.seq)
+			}
+			if rec.openedAfterClose {
+				t.Error("a loop was opened after it had been closed")
+			}
+		})
+	}
+}
+
+// A straggling client disconnect can arrive after the loops are gone.
+func TestClientDisconnectAfterLeaveIsSafe(t *testing.T) {
+	conn, _, _ := newAudioConn()
+
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	gatewayReady(conn)
+	sessionDescription(conn)
+	leaveChannel(conn)
+
+	conn.handleMessage(conn.gateway, OpcodeClientDisconnect, 0, GatewayMessageDataClientDisconnect{UserID: 9})
+}
+
+// The real loops, not the stubs: once the conn is usable the sender must
+// actually run, and closing it must actually stop it.
+func TestRealAudioLoopsRunOnceConnIsUsable(t *testing.T) {
+	udp := &udpConnStub{}
+	conn := newRealConn()
+	conn.udp = udp
+	conn.state.ChannelID = 3
+
+	pulled := make(chan struct{}, 64)
+	conn.SetOpusFrameProvider(signalProvider{pulled: pulled})
+	gatewayReady(conn)
+	sessionDescription(conn)
+
+	select {
+	case <-pulled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the sender never pulled a frame after the conn became usable")
+	}
+
+	leaveChannel(conn)
+	for len(pulled) > 0 {
+		<-pulled
+	}
+
+	select {
+	case <-pulled:
+		t.Fatal("the sender pulled a frame after it was closed")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// Close can land before the loop goroutine has run, so the cancel func must be
+// in place before Open spawns it.
+func TestClosingRealAudioLoopImmediatelyStopsIt(t *testing.T) {
+	conn := newRealConn()
+	conn.udp = &udpConnStub{}
+	conn.state.ChannelID = 3
+
+	pulled := make(chan struct{}, 64)
+	conn.SetOpusFrameProvider(signalProvider{pulled: pulled})
+	gatewayReady(conn)
+	sessionDescription(conn)
+	leaveChannel(conn)
+
+	time.Sleep(100 * time.Millisecond)
+	for len(pulled) > 0 {
+		<-pulled
+	}
+
+	select {
+	case <-pulled:
+		t.Fatal("the sender kept pulling frames after an immediate close")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// The receiver's cancel func must stop its loop, the same as the sender's.
+func TestClosingRealAudioReceiverStopsIt(t *testing.T) {
+	conn := newRealConn()
+	conn.udp = &udpConnStub{packet: &Packet{SSRC: 1}}
+	conn.state.ChannelID = 3
+
+	received := make(chan struct{}, 64)
+	conn.SetOpusFrameReceiver(signalReceiver{received: received})
+	gatewayReady(conn)
+	sessionDescription(conn)
+
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the receiver never handled a packet after the conn became usable")
+	}
+
+	leaveChannel(conn)
+	time.Sleep(100 * time.Millisecond)
+	for len(received) > 0 {
+		<-received
+	}
+
+	select {
+	case <-received:
+		t.Fatal("the receiver kept handling packets after it was closed")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// A client disconnect has to reach the receiver so it can drop that user.
+func TestClientDisconnectCleansUpUser(t *testing.T) {
+	conn, _, rec := newAudioConn()
+
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	gatewayReady(conn)
+	sessionDescription(conn)
+	conn.handleMessage(conn.gateway, OpcodeClientDisconnect, 0, GatewayMessageDataClientDisconnect{UserID: 9})
+
+	if !slices.Equal(rec.cleanedUp, []snowflake.ID{9}) {
+		t.Errorf("cleaned up = %v, want [9]", rec.cleanedUp)
+	}
+}
+
+// Closing a loop that never started must not call a nil cancel func.
+func TestClosingUnstartedRealAudioLoopIsSafe(t *testing.T) {
+	conn := newRealConn()
+
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+	conn.SetOpusFrameProvider(nopProvider{})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+}
+
+// Relies on the default DAVE session reporting ready; if that changes this
+// test goes vacuous.
+func TestRealAudioLoopsDoNotRunBeforeOpen(t *testing.T) {
+	conn := newRealConn()
+
+	pulled := make(chan struct{}, 1)
+	conn.SetOpusFrameProvider(signalProvider{pulled: pulled})
+	conn.SetOpusFrameReceiver(nopReceiver{})
+
+	select {
+	case <-pulled:
+		t.Fatal("sender pulled a frame before the udp conn was open")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func newRealConn() *connImpl {
+	return NewConn(1, 2,
+		func(context.Context, snowflake.ID, *snowflake.ID, bool, bool) error { return nil },
+		func() {},
+		WithConnLogger(slog.New(slog.DiscardHandler)),
+		WithConnDaveSessionLogger(slog.New(slog.DiscardHandler)),
+	).(*connImpl)
+}
+
+func newAudioConn() (*connImpl, *udpConnStub, *audioRecord) {
+	udp := &udpConnStub{}
+	rec := &audioRecord{udp: udp}
+
+	var conn *connImpl
+	conn = NewConn(1, 2,
+		func(_ context.Context, _ snowflake.ID, channelID *snowflake.ID, _ bool, _ bool) error {
+			if channelID != nil && conn.openedFunc != nil {
+				conn.openedFunc()
+			}
+			return nil
+		},
+		func() {},
+		WithConnLogger(slog.New(slog.DiscardHandler)),
+		WithConnDaveSessionLogger(slog.New(slog.DiscardHandler)),
+		WithConnAudioSenderCreateFunc(func(*slog.Logger, OpusFrameProvider, Conn) AudioSender {
+			return &audioSenderStub{rec: rec}
+		}),
+		WithConnAudioReceiverCreateFunc(func(*slog.Logger, OpusFrameReceiver, Conn) AudioReceiver {
+			return &audioReceiverStub{rec: rec}
+		}),
+	).(*connImpl)
+	conn.udp = udp
+	conn.state.ChannelID = 3
+
+	return conn, udp, rec
+}
+
+func gatewayReady(conn *connImpl) {
+	conn.handleMessage(conn.gateway, OpcodeReady, 0, GatewayMessageDataReady{
+		SSRC:  1,
+		IP:    "127.0.0.1",
+		Port:  1234,
+		Modes: AllEncryptionModes,
+	})
+}
+
+func sessionDescription(conn *connImpl) {
+	conn.handleMessage(conn.gateway, OpcodeSessionDescription, 0, GatewayMessageDataSessionDescription{
+		Mode:      EncryptionModeAEADXChaCha20Poly1305RTPSize,
+		SecretKey: make([]byte, 32),
+	})
+}
+
+func leaveChannel(conn *connImpl) {
+	conn.HandleVoiceStateUpdate(botgateway.EventVoiceStateUpdate{VoiceState: discord.VoiceState{
+		GuildID: 1,
+		UserID:  2,
+	}})
+}
+
+func assertLoopsOpened(t *testing.T, when string, rec *audioRecord, want int) {
+	t.Helper()
+
+	if rec.senderOpens != want || rec.receiverOpens != want {
+		t.Errorf("open calls %s: sender=%d receiver=%d, want %d and %d", when, rec.senderOpens, rec.receiverOpens, want, want)
+	}
+	if rec.openedUnusable {
+		t.Errorf("a loop was opened while the udp conn was unusable %s", when)
+	}
+	if rec.openedAfterClose {
+		t.Errorf("a loop was opened after it had been closed %s", when)
+	}
+}
+
+// audioRecord accumulates across every loop instance the create funcs mint, so
+// a test can tell a replacement apart from a reopened instance.
+type audioRecord struct {
+	udp              *udpConnStub
+	senderOpens      int
+	senderCloses     int
+	receiverOpens    int
+	receiverCloses   int
+	openedUnusable   bool
+	openedAfterClose bool
+	cleanedUp        []snowflake.ID
+	seq              []string
+}
+
+func (r *audioRecord) open(name string, closed bool) {
+	r.seq = append(r.seq, name+".open")
+	if !r.udp.usable() {
+		r.openedUnusable = true
+	}
+	if closed {
+		r.openedAfterClose = true
+	}
+}
+
+type audioSenderStub struct {
+	rec    *audioRecord
+	closed bool
+}
+
+func (s *audioSenderStub) Open() {
+	s.rec.senderOpens++
+	s.rec.open("sender", s.closed)
+}
+
+func (s *audioSenderStub) Close() {
+	s.closed = true
+	s.rec.senderCloses++
+	s.rec.seq = append(s.rec.seq, "sender.close")
+}
+
+type audioReceiverStub struct {
+	rec    *audioRecord
+	closed bool
+}
+
+func (s *audioReceiverStub) Open() {
+	s.rec.receiverOpens++
+	s.rec.open("receiver", s.closed)
+}
+
+func (s *audioReceiverStub) Close() {
+	s.closed = true
+	s.rec.receiverCloses++
+	s.rec.seq = append(s.rec.seq, "receiver.close")
+}
+
+func (s *audioReceiverStub) CleanupUser(userID snowflake.ID) {
+	s.rec.cleanedUp = append(s.rec.cleanedUp, userID)
+}
+
+type nopProvider struct{}
+
+func (nopProvider) ProvideOpusFrame() ([]byte, error) { return nil, nil }
+func (nopProvider) Close()                            {}
+
+// signalProvider reports that the sender loop pulled a frame.
+type signalProvider struct {
+	pulled chan struct{}
+}
+
+func (p signalProvider) ProvideOpusFrame() ([]byte, error) {
+	select {
+	case p.pulled <- struct{}{}:
+	default:
+	}
+	return nil, nil
+}
+func (signalProvider) Close() {}
+
+// signalReceiver reports that the receiver loop handled a packet.
+type signalReceiver struct {
+	received chan struct{}
+}
+
+func (r signalReceiver) ReceiveOpusFrame(snowflake.ID, *Packet) error {
+	select {
+	case r.received <- struct{}{}:
+	default:
+	}
+	return nil
+}
+func (signalReceiver) CleanupUser(snowflake.ID) {}
+func (signalReceiver) Close()                   {}
+
+type nopReceiver struct{}
+
+func (nopReceiver) ReceiveOpusFrame(snowflake.ID, *Packet) error { return nil }
+func (nopReceiver) CleanupUser(snowflake.ID)                     {}
+func (nopReceiver) Close()                                       {}


### PR DESCRIPTION
Fixes #595 

@topi314 Following our conversation yesterday I went digging into this more and I identified something interesting when trying to make sense of my AI agents mess of #596. 

The original issue was that I originally had a setup I builds the audio pipeline before it connects:

```go
conn := client.VoiceManager.CreateConn(guildID)

// set up where the audio goes, then go and get some
conn.SetOpusFrameReceiver(recorder)

if err := conn.Open(ctx, channelID, false, false); err != nil {
    return err
}
```

That paniced on a nil pointer and took the process with it. The docs show doing the open first, but I didnt actually see that till this morning, and (at least for me personally) this way round seemed more intuitive. _But this is what the original PR was meant to address_, the handling of that nil pointer if you order things in the way I do above. (There is probably an easier version of this PR that just involves documentation and something to enforce ordering but I didnt want to implement a contract change and trigger a major release)

Both setters start their loop the moment you call them, but that loop reads and writes the UDP conn, and the conn isn't dialled until the gateway's ready event. The encrypter isn't there either until the session description lands. So if you register audio before `Conn.Open` then the loop spends the whole handshake running against nils.

I did wonder whether the `DAVE().Ready()` check at the top of both loops already
covered it. It doesn't! The default is `godave.NewNoopSession`, whose `Ready()`
returns true unconditionally, so that gate is open on every default setup.

## The solution

Instead of guarding the dereference (as in #596 ) and returning an error. This tries to address the allow looser ordering instead. The loops start start conn can actually back them, so registering early works instead of panicing, and there's no error to handle because the state that caused it doesn't arise.

The documented order is untouched. `Conn.Open` only returns after the session description, so a setter called after it starts its loop straight away, exactly as now. `TestAudioLoopsStartWhenConnIsReady` passes on master as well as on this branch, which is what pins it.

Two numbers:

- The example i gave above currently panics on `master`. `TestRealAudioLoopsDoNotRunBeforeOpen` reproduces it against the real types.
- With one `SetOpusFrameProvider` racing the handshake, over 300,000 test runs,
  the current `master` starts a loop against a conn that can't back it 3,844 times. My proposed solution in this PR results in zero 

To make this work for both audio Sender and Reciever, `Open()` now creates the cancel func before it spawns the goroutine rather than inside it, and introduced a small single purpose mutex. Without it, Open racing Close panics on a nil cancel func on master, and with just a nil check it still races. -race catches that within a couple of hundred iterations.

It isn't just a case of me tidying up either. Once the loop has started, if later than the setter that registered it, you can end up closing one that never actually ran, and on `master` that calls a nil func and panics. The two calls also end up on different goroutines: the voice gateway is what starts a loop registered early, while the caller is what closes it. So the field needed guarding either way. Without the mutex, `-race` picks it up within a couple of hundred iterations.

## What it doesn't do

I kept this deliberately narrow. These are all untouched and behave exactly as they do on `master` today:

- Audio still doesn't restart by itself after a gateway reconnect. I left that path alone entirely.
- A loop that's already running when a re-dial fails still panics on its next write.
- There's no new synchronisation beyond the audio fields themselves.

Happy to look at any of those separately if you want them, but they each felt like a different change to me. Feel free to close/reject #596 