### PR TITLE
fix(audit-log): correct name for VoiceChannelStatusCreate (192)

### DIFF
--- a/discord/audit_log.go
+++ b/discord/audit_log.go
@@ -130,7 +130,7 @@ const (
 )
 
 const (
-	AuditLogVoiceChannelStatusUpdate AuditLogEvent = iota + 192
+	AuditLogVoiceChannelStatusCreate AuditLogEvent = iota + 192
 	AuditLogVoiceChannelStatusDelete
 )
 


### PR DESCRIPTION
https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events