### PR TITLE
fix(discord): add missing PremiumRequired interaction response type

### DIFF
--- a/discord/interaction_response.go
+++ b/discord/interaction_response.go
@@ -19,7 +19,7 @@ const (
 	InteractionResponseTypeUpdateMessage
 	InteractionResponseTypeAutocompleteResult
 	InteractionResponseTypeModal
-	_
+	InteractionResponseTypePremiumRequired
 	_
 	InteractionResponseTypeLaunchActivity
 )


### PR DESCRIPTION
https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object