### PR TITLE
improve actions' dependency pinning

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,4 @@
 name: Go
-
 on:
   pull_request:
     paths:
@@ -7,15 +6,12 @@ on:
       - '**/go.mod'
       - '**/go.sum'
       - '.github/workflows/go.yml'
-
   push:
     paths:
       - '**/*.go'
       - '**/go.mod'
       - '**/go.sum'
       - '.github/workflows/go.yml'
-
-
 # The if of each job prevents running the workflow if it's from a pull request from the directory the pull request is targeted towards
 # as it will already run on 'push'
 jobs:
@@ -23,33 +19,31 @@ jobs:
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: 1.24
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: go build
         run: go build -v ./...
-
   test:
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: 1.24
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: go test
         run: go test -v ./...
-
   golangci:
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: 1.24
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@db9de0fc1a667e1a49d2291a1a042dff081d78f6 # v9
         with:
-          version: latest
+          version: v2.12


### PR DESCRIPTION
improve workflow dependency pinning by pinning action versions to SHA hashes instead of version tags.

for the `golangci-lint` version specifically (the tool, not the action), i've swapped it from `latest` to `v2.12` per the [official golangci-lint recommendation](https://golangci-lint.run/docs/product/roadmap/?utm_source=copilot.com#:~:text=As%20such%2C%20we%20recommend%20using%20the%20fixed%20minor%20version%20and%20fixed%20or%20the%20latest%20patch%20version%20to%20guarantee%20the%20results%20of%20your%20builds).

also, some whitespace was removed by `yamlfmt`. 

no huge fixes, just trying to go through some open source projects and do some minor devops changes.