### PR TITLE
deprecate(connection): drop deprecated ConnectionTypeBattleNet

### DIFF
--- a/discord/connection.go
+++ b/discord/connection.go
@@ -15,7 +15,7 @@ type Connection struct {
 type ConnectionType string
 
 const (
-	ConnectionTypeAmazonMusic        ConnectionType = "amazon-music"
+	ConnectionTypeAmazonMusic ConnectionType = "amazon-music"
 	// Deprecated: will be removed permanently on 2026-09-22.
 	ConnectionTypeBattleNet          ConnectionType = "battlenet"
 	ConnectionTypeBluesky            ConnectionType = "bluesky"

--- a/discord/connection.go
+++ b/discord/connection.go
@@ -16,6 +16,8 @@ type ConnectionType string
 
 const (
 	ConnectionTypeAmazonMusic        ConnectionType = "amazon-music"
+	// Deprecated: will be removed permanently on 2026-09-22.
+	ConnectionTypeBattleNet          ConnectionType = "battlenet"
 	ConnectionTypeBluesky            ConnectionType = "bluesky"
 	ConnectionTypeBungie             ConnectionType = "bungie"
 	ConnectionTypeCrunchyroll        ConnectionType = "crunchyroll"

--- a/discord/connection.go
+++ b/discord/connection.go
@@ -16,7 +16,6 @@ type ConnectionType string
 
 const (
 	ConnectionTypeAmazonMusic        ConnectionType = "amazon-music"
-	ConnectionTypeBattleNet          ConnectionType = "battlenet"
 	ConnectionTypeBluesky            ConnectionType = "bluesky"
 	ConnectionTypeBungie             ConnectionType = "bungie"
 	ConnectionTypeCrunchyroll        ConnectionType = "crunchyroll"


### PR DESCRIPTION
I've opened this PR as disgo removes the deprecated features even before they're officially removed.
Related docs PR: https://github.com/discord/discord-api-docs/pull/8546